### PR TITLE
Compare every namespace at once, and redesign the TUI around it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ ratatui = "0.29.0"
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
 serde_yaml = "0.9.27"
-futures = "0.3.29"
 tokio = { version = "1.34.0", features = ["full"] }
 anyhow = "1.0.75"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ serde_yaml = "0.9.27"
 futures = "0.3.29"
 tokio = { version = "1.34.0", features = ["full"] }
 anyhow = "1.0.75"
+
+[dev-dependencies]
+speculoos = { version = "0.13.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "giter"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ A small utility for checking which commit is currently deployed in your Kubernet
 
 ## Description
 
-This tool helps you quickly verify what git commit is running in your Kubernetes pods by inspecting pod labels and cross-referencing them with your local git repositories.
+This tool helps you quickly verify what git commit is running in your Kubernetes pods. It reads the commit
+hash out of each container's image tag and compares it with the tip of the repository's default branch, so
+you can see at a glance where a stale build is still running.
 
 ## Installation
 
@@ -29,24 +31,32 @@ giter [OPTIONS]
 
 ### Options
 
-- `-n, --namespace <NAMESPACE>` - Kubernetes namespace to check pods in. If not provided, uses the current namespace from your kubeconfig
+- `-m, --mode <MODE>` - What a pod is expected to run: `commit` (tip of the default branch, the default) or
+  `tag` (the commit behind the latest tag)
+- `-n, --namespace <NAMESPACE>` - Show a single namespace instead of every namespace listed in `repos.json`
 - `-s, --storage-path <PATH>` - Path to the repos.json file (default: `./repos.json`)
 - `-h, --help` - Print help
 - `-V, --version` - Print version
 
 ### Examples
 
-Use current namespace from kubeconfig:
+Every namespace listed in `repos.json`:
 
 ```bash
 giter
 ```
 
-Specify a namespace:
+A single namespace:
 
 ```bash
 giter -n micro-1
 giter --namespace gateway
+```
+
+Production, where every pod is supposed to run the latest tagged release:
+
+```bash
+giter --mode tag
 ```
 
 Specify a custom storage path:
@@ -57,14 +67,44 @@ giter -s /path/to/repos.json
 
 ## How It Works
 
-1. Reads the current namespace from kubeconfig or uses the `-n` flag
-2. Fetches all pods in the specified namespace
-3. Displays pod information with commit hashes
-4. Cross-references commits with local git repositories from `repos.json`
+1. Takes the namespaces from `repos.json`, or the single one given with `-n`
+2. Lists the pods of every namespace in parallel
+3. Asks every repository for its target commit in the background — no API token needed, your existing git
+   credentials apply
+4. Reads the commit hash from each image tag, which CI builds as `<short sha>-<pipeline id>`, and compares it
+   with that target
+
+The target depends on the mode:
+
+- `commit` - `git ls-remote <url> HEAD`, the tip of the default branch
+- `tag` - `git ls-remote --tags --sort=-v:refname <url>`, the commit behind the highest version tag. Sorting is
+  left to `git`, whose version sort puts `v0.1.100` above `v0.1.99` — plain alphabetical would not. Annotated
+  tags are followed to the commit they point at
+
+Both lookups are cached per mode, so toggling with `m` only fetches what is missing.
+
+Colours:
+
+- **green** - running the target commit
+- **red** - running something else
+- **grey** - nothing to compare: a sidecar pinned to a version, a repository without tags, a namespace missing
+  from `repos.json`, or a lookup that is still running or failed
+
+### Keys
+
+| Key | Action |
+| --- | --- |
+| `↑` `↓` / `k` `j` | move within the pane |
+| `←` `→` / `h` `l` / `Tab` | switch pane |
+| `Enter` | walk right through the panes, open the commit in a browser on the last one |
+| `m` | switch between `commit` and `tag` mode |
+| `r` | re-run the lookup for the selected namespace |
+| `q` / `Esc` | quit |
 
 ## repos.json Format
 
-The storage file contains mappings of repository paths to their commit hashes:
+`name` must be the **Kubernetes namespace**, not the repository name — that is what the pods are matched
+against. `url` is the base project URL without a trailing slash; `/-/commit/<hash>` is appended to it.
 
 ```json
 [
@@ -84,10 +124,11 @@ The storage file contains mappings of repository paths to their commit hashes:
 - Rust toolchain
 - Kubernetes access configured via kubeconfig
 - `kubectl` access to the target namespace
+- `git` in `PATH`, with read access to the repositories
 
 ## Roadmap
 
-- [ ] Add tests
+- [x] Add tests
 - [ ] Add custom rules for specifying commit
 - [ ] Optionally use tags
 - [ ] Themes

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ This tool helps you quickly verify what git commit is running in your Kubernetes
 hash out of each container's image tag and compares it with the tip of the repository's default branch, so
 you can see at a glance where a stale build is still running.
 
+It opens on an overview of every namespace at once, worst first, and `Enter` takes one apart: its pods, what
+each of them runs, and how healthy they are. The header names the cluster you are looking at, because
+mistaking production for staging is the easiest mistake to make.
+
 ## Installation
 
 Build from source:
@@ -35,6 +39,7 @@ giter [OPTIONS]
   `tag` (the commit behind the latest tag)
 - `-n, --namespace <NAMESPACE>` - Show a single namespace instead of every namespace listed in `repos.json`
 - `-s, --storage-path <PATH>` - Path to the repos.json file (default: `./repos.json`)
+- `--colorblind` - Use blue and orange instead of green and red
 - `-h, --help` - Print help
 - `-V, --version` - Print version
 
@@ -68,10 +73,11 @@ giter -s /path/to/repos.json
 ## How It Works
 
 1. Takes the namespaces from `repos.json`, or the single one given with `-n`
-2. Lists the pods of every namespace in parallel
-3. Asks every repository for its target commit in the background — no API token needed, your existing git
+2. Draws the table straight away — the names are known before the cluster has answered anything
+3. Lists the pods of every namespace in parallel, filling rows in as they arrive
+4. Asks every repository for its target commit in the background — no API token needed, your existing git
    credentials apply
-4. Reads the commit hash from each image tag, which CI builds as `<short sha>-<pipeline id>`, and compares it
+5. Reads the commit hash from each image tag, which CI builds as `<short sha>-<pipeline id>`, and compares it
    with that target
 
 The target depends on the mode:
@@ -83,23 +89,67 @@ The target depends on the mode:
 
 Both lookups are cached per mode, so toggling with `m` only fetches what is missing.
 
-Colours:
+The environment badge comes from the current kubeconfig context: a name containing `prod`, `stag` or `dev`
+tints the whole header. Anything else is shown without a badge.
 
-- **green** - running the target commit
-- **red** - running something else
-- **grey** - nothing to compare: a sidecar pinned to a version, a repository without tags, a namespace missing
-  from `repos.json`, or a lookup that is still running or failed
+### What a row says
+
+Every row carries a glyph as well as a colour, so it reads in a monochrome terminal and under colour
+blindness. When there is nothing to compare, a short code says why — the same four reasons no longer share
+one shade of grey.
+
+| Glyph | Meaning | Code | |
+| --- | --- | --- | --- |
+| `●` green | in sync | | deployed commit equals the reference |
+| `▼` red | behind | | deployed commit differs from the reference |
+| `✗` orange | failed | `k8s` | cannot list pods — no access or no such namespace |
+| `✗` orange | failed | `git` | `ls-remote` failed, the reason is in the row |
+| `⠙` grey | resolving | | the reference is still being fetched |
+| `○` grey | unknown | `sidecar` | foreign image, such as a service mesh proxy |
+| `○` grey | unknown | `digest` | pinned by digest, the tag carries no commit |
+| `○` grey | unknown | `no-cfg` | namespace has no entry in `repos.json` |
+| `○` grey | unknown | `no-tags` | tag mode, but the repository has no tags |
+| `○` grey | unknown | `mode` | a release image, which `commit` mode has no tag list to resolve |
+| `○` grey | unknown | `done` | the pod has run its course — what a CronJob leaves behind |
+| `○` grey | unknown | `no-pods` | no pods, so nothing to compare |
+
+The DEPLOYED column is named after what it holds: `DEPLOYED COMMIT` where pods run branch builds and
+`DEPLOYED TAG` where they run releases. That does not follow the mode — the mode says what pods are compared
+against, not what they carry — so a cluster deployed from releases says `TAG` even in `commit` mode.
+
+One lagging pod makes a namespace red, and a namespace is green when every pod that can be judged is. What
+cannot be judged is left out rather than dragging everything down with it: a sidecar pinned to its own
+version, a pod belonging to somebody else's workload that happens to share the namespace, and a pod that has
+already finished — what a CronJob leaves behind ran the code that was current at the time and deploys nothing
+now — say nothing about the release and are not counted as deployed commits either. Only when nothing at all can be judged does
+the namespace take on the reason why. The DEPLOYED COMMIT column lists every distinct commit its own pods run
+with a count, so a rollout that stopped half way through shows up as two groups.
+
+In the overview the prefix a namespace shares with its family is dimmed rather than cut, and it is the prefix
+that gives up room first when the column runs out. The list on the namespace screen goes further: it groups
+namespaces under a heading carrying that whole shared prefix, so the rows below show only what tells them
+apart.
+
+Below 100 columns the table drops to name, commit and pod count; below 60×15 it says so instead of drawing
+something unreadable.
 
 ### Keys
 
 | Key | Action |
 | --- | --- |
-| `↑` `↓` / `k` `j` | move within the pane |
-| `←` `→` / `h` `l` / `Tab` | switch pane |
-| `Enter` | walk right through the panes, open the commit in a browser on the last one |
+| `↑` `↓` / `k` `j` | move |
+| `PgUp` `PgDn` / `Home` `End` | jump ten rows / to either end |
+| `Enter` | open the namespace, or open the deployed commit in a browser |
+| `←` `→` / `h` `l` / `Tab` | switch pane, or step back to the overview |
+| `Esc` | dismiss a message, leave the namespace, quit |
+| `/` | search namespaces |
+| `f` | filter: all / problems / unknown |
+| `s` | sort: status / name / pods |
 | `m` | switch between `commit` and `tag` mode |
-| `r` | re-run the lookup for the selected namespace |
-| `q` / `Esc` | quit |
+| `r` | re-resolve the selected namespace |
+| `R` | re-list the pods from Kubernetes |
+| `?` | full key map and legend |
+| `q` | quit |
 
 ## repos.json Format
 
@@ -129,8 +179,8 @@ against. `url` is the base project URL without a trailing slash; `/-/commit/<has
 ## Roadmap
 
 - [x] Add tests
+- [x] Optionally use tags
 - [ ] Add custom rules for specifying commit
-- [ ] Optionally use tags
 - [ ] Themes
 - [ ] CLI mode
 - [ ] GitHub support

--- a/src/caller/browser.rs
+++ b/src/caller/browser.rs
@@ -1,5 +1,9 @@
 use ::open;
 
-pub fn open_with_hash(url: &String, hash: &String) -> Result<(), std::io::Error> {
-    open::that(format!("{}/-/commit/{}", url, hash))
+pub fn commit_url(url: &str, hash: &str) -> String {
+    format!("{}/-/commit/{}", url, hash)
+}
+
+pub fn open_with_hash(url: &str, hash: &str) -> Result<(), std::io::Error> {
+    open::that(commit_url(url, hash))
 }

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -16,4 +16,8 @@ pub struct Args {
     /// Show a single namespace instead of every namespace listed in repos.json
     #[arg(short, long)]
     pub namespace: Option<String>,
+
+    /// Use blue and orange instead of green and red
+    #[arg(long)]
+    pub colorblind: bool,
 }

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -1,14 +1,19 @@
+use crate::git::remote::Mode;
 use clap::Parser;
 
 /// Simple utility for quickly checking what commit in this pod
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
+    /// What a pod is expected to run: the tip of the default branch, or the latest tag
+    #[arg(short, long, value_enum, default_value_t = Mode::Commit)]
+    pub mode: Mode,
+
     /// Path to repos.json file
     #[arg(short, long, default_value_t = String::from("./repos.json"))]
     pub storage_path: String,
 
-    /// Namespace where images would be checked
+    /// Show a single namespace instead of every namespace listed in repos.json
     #[arg(short, long)]
     pub namespace: Option<String>,
 }

--- a/src/drawer/app.rs
+++ b/src/drawer/app.rs
@@ -1,74 +1,310 @@
 use crate::caller::browser::{commit_url, open_with_hash};
+use crate::errors::MsgError;
 use crate::git::remote::{
-    commit_status, spawn_lookup, CommitStatus, LookupResult, Mode, RemoteState,
+    judge, spawn_lookup, Failure, ImageRef, LookupError, LookupResult, Mode, RemoteState,
+    Unresolved, Verdict,
 };
+use crate::k8s::context::Cluster;
 use crate::k8s::pods::{MyContainer, MyPod};
 use crate::storage::json_storage::JsonStorage;
-use ratatui::widgets::ListState;
+use crate::text::{family_prefix, shared_prefix, short_duration, split_pod_name};
+use k8s_openapi::chrono::Utc;
+use kube::Client;
+use ratatui::widgets::TableState;
 use std::collections::HashMap;
-use std::sync::mpsc::{channel, Receiver, Sender, TryRecvError};
+use std::sync::mpsc::{channel, Receiver, Sender};
+use std::time::{Duration, Instant};
 
-pub const KEY_HINTS: &str = "↑↓ move · ←→/Tab pane · Enter open · m mode · r refresh · q quit";
+/// How long a reported action stays in the footer before the summary comes back.
+const NOTE_TTL: Duration = Duration::from_secs(6);
+/// Deployed commits shown per namespace before the rest is counted as `+N`.
+const DEPLOYED_GROUPS: usize = 2;
+const SPINNER: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+/// Frames one spinner step lasts, at roughly ten frames per second.
+const SPINNER_STEP: usize = 2;
+const MISSING: &str = "—";
 
 #[derive(Clone, Copy, PartialEq, Eq)]
-pub enum Focus {
+pub enum Screen {
+    Overview,
+    Detail,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Input {
+    Normal,
+    Search,
+    Help,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Pane {
     Namespaces,
     Pods,
     Containers,
 }
 
-pub struct NamespaceEntry {
-    pub name: String,
-    pub pods: Vec<MyPod>,
-    /// Set when listing pods failed — the namespace stays visible instead of vanishing.
-    pub error: Option<String>,
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Filter {
+    All,
+    Problems,
+    Unknown,
 }
 
+impl Filter {
+    pub fn label(self) -> &'static str {
+        match self {
+            Filter::All => "all",
+            Filter::Problems => "problems",
+            Filter::Unknown => "unknown",
+        }
+    }
+
+    fn next(self) -> Filter {
+        match self {
+            Filter::All => Filter::Problems,
+            Filter::Problems => Filter::Unknown,
+            Filter::Unknown => Filter::All,
+        }
+    }
+
+    fn accepts(self, verdict: Verdict) -> bool {
+        match self {
+            Filter::All => true,
+            Filter::Problems => matches!(verdict, Verdict::Behind | Verdict::Failed(_)),
+            Filter::Unknown => matches!(verdict, Verdict::Resolving | Verdict::Unknown(_)),
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Sort {
+    Status,
+    Name,
+    Pods,
+}
+
+impl Sort {
+    pub fn label(self) -> &'static str {
+        match self {
+            Sort::Status => "status",
+            Sort::Name => "name",
+            Sort::Pods => "pods",
+        }
+    }
+
+    fn next(self) -> Sort {
+        match self {
+            Sort::Status => Sort::Name,
+            Sort::Name => Sort::Pods,
+            Sort::Pods => Sort::Status,
+        }
+    }
+}
+
+/// What is known about the pods of one namespace.
+pub enum PodsState {
+    Listing,
+    Ready(Vec<MyPod>),
+    Failed(String),
+}
+
+pub struct Entry {
+    pub name: String,
+    pub pods: PodsState,
+}
+
+impl Entry {
+    fn pod_list(&self) -> &[MyPod] {
+        match &self.pods {
+            PodsState::Ready(pods) => pods,
+            _ => &[],
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum NoteKind {
+    Ok,
+    Warn,
+    Error,
+}
+
+/// One line about what just happened, or about why the selected namespace cannot be judged.
+pub struct Note {
+    pub kind: NoteKind,
+    pub text: String,
+    pub retry: bool,
+    /// A standing problem, read off the state rather than reported once. Esc cannot make it
+    /// go away, so the footer must not offer to.
+    pub standing: bool,
+}
+
+#[derive(Default)]
+pub struct Counts {
+    pub in_sync: usize,
+    pub behind: usize,
+    pub failed: usize,
+    pub unknown: usize,
+}
+
+/// What the references on screen are. The mode says what pods are compared *against*, not
+/// what they carry: a cluster built from branches runs commits even in tag mode, and one
+/// built from releases runs tags even in commit mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefKind {
+    Commits,
+    Tags,
+    Mixed,
+}
+
+/// One deployed reference and how many pods run it.
+pub struct Deployed {
+    pub label: String,
+    pub count: usize,
+    pub verdict: Verdict,
+}
+
+/// A namespace as the tables show it.
+pub struct NsRow {
+    pub name: String,
+    /// Characters of the shared prefix, dimmed instead of cut.
+    pub prefix: usize,
+    pub verdict: Verdict,
+    pub pods: Option<usize>,
+    pub deployed: Vec<Deployed>,
+    pub hidden_deployed: usize,
+    pub reference: String,
+    pub note: String,
+}
+
+/// The namespace list of the detail screen, where families get a heading.
+pub enum MiniRow {
+    Family(String),
+    Namespace(NsRow),
+}
+
+pub struct PodRow {
+    pub prefix: String,
+    pub replicaset: String,
+    pub suffix: String,
+    pub verdict: Verdict,
+    pub reference: String,
+    pub status: String,
+    pub restarts: i32,
+    pub age: String,
+    pub readiness: String,
+}
+
+pub struct ContainerRow {
+    pub name: String,
+    pub tag: String,
+    pub verdict: Verdict,
+    /// Plain words for the verdict, so a grey row never stays unexplained.
+    pub why: String,
+}
+
+/// Round the listing belongs to, the namespace, and what came back.
+type PodsResult = (u64, String, Result<Vec<MyPod>, MsgError>);
+
 pub struct App {
-    namespaces: Vec<NamespaceEntry>,
+    pub cluster: Cluster,
+    entries: Vec<Entry>,
     repos: JsonStorage,
+    kube: Client,
     mode: Mode,
     /// Results are kept per mode, so switching back and forth costs nothing.
     remotes: HashMap<Mode, HashMap<String, RemoteState>>,
-    tx: Sender<LookupResult>,
-    lookups: Receiver<LookupResult>,
-    focus: Focus,
-    ns_state: ListState,
-    pod_state: ListState,
-    cont_state: ListState,
-    status: String,
+    lookups_tx: Sender<LookupResult>,
+    lookups_rx: Receiver<LookupResult>,
+    pods_tx: Sender<PodsResult>,
+    pods_rx: Receiver<PodsResult>,
+
+    screen: Screen,
+    input: Input,
+    pane: Pane,
+    filter: Filter,
+    sort: Sort,
+    query: String,
+
+    /// Selection is remembered by name: the table reorders as answers arrive, and the
+    /// cursor has to stay on the row the user was looking at.
+    ns_pick: Option<String>,
+    pod_pick: Option<String>,
+    cont_pick: Option<String>,
+    ns_state: TableState,
+    pod_state: TableState,
+    cont_state: TableState,
+
+    note: Option<(Note, Instant)>,
+    /// Which round of pod listing is current: answers from an earlier one are dropped
+    /// rather than allowed to reinstate a stale list of pods.
+    listing_round: u64,
+    listed_at: Option<Instant>,
+    resolved_at: Option<Instant>,
+    frame: usize,
+    /// Set by the renderer: some keys mean something else when a pane is not on screen.
+    narrow: bool,
     should_quit: bool,
 }
 
 impl App {
-    pub fn new(namespaces: Vec<NamespaceEntry>, repos: JsonStorage, mode: Mode) -> App {
-        let (tx, lookups) = channel();
-
-        let mut ns_state = ListState::default();
-        if !namespaces.is_empty() {
-            ns_state.select(Some(0));
-        }
+    pub fn new(
+        names: Vec<String>,
+        repos: JsonStorage,
+        mode: Mode,
+        cluster: Cluster,
+        kube: Client,
+    ) -> App {
+        let (lookups_tx, lookups_rx) = channel();
+        let (pods_tx, pods_rx) = channel();
 
         let mut app = App {
-            namespaces,
+            cluster,
+            entries: names
+                .into_iter()
+                .map(|name| Entry {
+                    name,
+                    pods: PodsState::Listing,
+                })
+                .collect(),
             repos,
+            kube,
             mode,
             remotes: HashMap::new(),
-            tx,
-            lookups,
-            focus: Focus::Namespaces,
-            ns_state,
-            pod_state: ListState::default(),
-            cont_state: ListState::default(),
-            status: String::new(),
+            lookups_tx,
+            lookups_rx,
+            pods_tx,
+            pods_rx,
+            screen: Screen::Overview,
+            input: Input::Normal,
+            pane: Pane::Pods,
+            filter: Filter::All,
+            sort: Sort::Status,
+            query: String::new(),
+            ns_pick: None,
+            pod_pick: None,
+            cont_pick: None,
+            ns_state: TableState::default(),
+            pod_state: TableState::default(),
+            cont_state: TableState::default(),
+            note: None,
+            listing_round: 0,
+            listed_at: None,
+            resolved_at: None,
+            frame: 0,
+            narrow: false,
             should_quit: false,
         };
 
-        app.reset_pods();
+        app.relist_pods();
         app.request_missing();
+        app.normalize();
 
         app
     }
+
+    // ---------------------------------------------------------------- state of the world
 
     pub fn should_quit(&self) -> bool {
         self.should_quit
@@ -78,238 +314,848 @@ impl App {
         self.should_quit = true;
     }
 
-    pub fn focus(&self) -> Focus {
-        self.focus
+    pub fn screen(&self) -> Screen {
+        self.screen
     }
 
-    /// The last action reported to the user, or the state of the background lookups
-    /// while there is nothing to report.
-    pub fn footer(&self) -> String {
-        if !self.status.is_empty() {
-            return self.status.clone();
-        }
+    pub fn input(&self) -> Input {
+        self.input
+    }
 
-        if let Some(problem) = self.selected_problem() {
-            return problem;
-        }
-
-        let pending = self.current_remotes().map_or(0, |remotes| {
-            remotes
-                .values()
-                .filter(|state| matches!(state, RemoteState::Loading))
-                .count()
-        });
-
-        if pending > 0 {
-            return format!("mode: {} · resolving · {} left", self.mode.label(), pending);
-        }
-
-        let statuses: Vec<CommitStatus> = self
-            .namespaces
-            .iter()
-            .map(|entry| self.namespace_status(entry))
-            .collect();
-
-        let outdated = statuses
-            .iter()
-            .filter(|s| **s == CommitStatus::Outdated)
-            .count();
-        let unresolved = statuses
-            .iter()
-            .filter(|s| **s == CommitStatus::Unknown)
-            .count();
-
-        let mut text = format!(
-            "mode: {} · {} of {} namespaces outdated",
-            self.mode.label(),
-            outdated,
-            statuses.len()
-        );
-        if unresolved > 0 {
-            text.push_str(&format!(" · {} unresolved", unresolved));
-        }
-
-        text
+    pub fn pane(&self) -> Pane {
+        self.pane
     }
 
     pub fn mode(&self) -> Mode {
         self.mode
     }
 
-    /// Switching modes reuses whatever was already resolved and only asks for the rest.
-    pub fn toggle_mode(&mut self) {
-        self.mode = self.mode.toggled();
-        self.status.clear();
-        self.request_missing();
+    pub fn filter(&self) -> Filter {
+        self.filter
     }
 
-    pub fn namespaces(&self) -> &[NamespaceEntry] {
-        &self.namespaces
+    pub fn sort(&self) -> Sort {
+        self.sort
     }
 
-    pub fn ns_state(&mut self) -> &mut ListState {
-        &mut self.ns_state
+    pub fn query(&self) -> &str {
+        &self.query
     }
 
-    pub fn pod_state(&mut self) -> &mut ListState {
-        &mut self.pod_state
+    pub fn narrow(&self) -> bool {
+        self.narrow
     }
 
-    pub fn cont_state(&mut self) -> &mut ListState {
-        &mut self.cont_state
+    pub fn set_narrow(&mut self, narrow: bool) {
+        self.narrow = narrow;
     }
 
-    pub fn selected_namespace(&self) -> Option<&NamespaceEntry> {
-        self.namespaces.get(self.ns_state.selected()?)
+    pub fn spinner(&self) -> char {
+        SPINNER[(self.frame / SPINNER_STEP) % SPINNER.len()]
     }
 
-    pub fn selected_pod(&self) -> Option<&MyPod> {
-        self.selected_namespace()?
-            .pods
-            .get(self.pod_state.selected()?)
+    /// Picks up whatever the background work has finished, then keeps the selection
+    /// pointing at rows that still exist.
+    pub fn tick(&mut self) {
+        self.frame = self.frame.wrapping_add(1);
+        self.drain_pods();
+        self.drain_lookups();
+        self.normalize();
     }
 
-    pub fn selected_container(&self) -> Option<&MyContainer> {
-        self.selected_pod()?
-            .containers
-            .get(self.cont_state.selected()?)
+    /// How many namespaces have been listed out of how many, while any is still pending.
+    pub fn listing(&self) -> Option<(usize, usize)> {
+        let done = self
+            .entries
+            .iter()
+            .filter(|e| !matches!(e.pods, PodsState::Listing))
+            .count();
+
+        match done == self.entries.len() {
+            true => None,
+            false => Some((done, self.entries.len())),
+        }
     }
+
+    /// Repositories whose reference is still being fetched in the current mode.
+    pub fn resolving(&self) -> usize {
+        self.entries
+            .iter()
+            .filter(|e| matches!(self.remote(&e.name), None | Some(RemoteState::Loading)))
+            .count()
+    }
+
+    pub fn counts(&self) -> Counts {
+        let mut counts = Counts::default();
+
+        for entry in &self.entries {
+            match self.namespace_verdict(entry) {
+                Verdict::InSync => counts.in_sync += 1,
+                Verdict::Behind => counts.behind += 1,
+                Verdict::Failed(_) => counts.failed += 1,
+                Verdict::Resolving | Verdict::Unknown(_) => counts.unknown += 1,
+            }
+        }
+
+        counts
+    }
+
+    pub fn total_namespaces(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn total_pods(&self) -> usize {
+        self.entries.iter().map(|e| e.pod_list().len()).sum()
+    }
+
+    pub fn total_containers(&self) -> usize {
+        self.entries
+            .iter()
+            .flat_map(|e| e.pod_list())
+            .map(|p| p.containers.len())
+            .sum()
+    }
+
+    /// How long ago each side last answered, e.g. `k8s 4m ago · git 12s ago`.
+    pub fn freshness(&self) -> String {
+        let parts: Vec<String> = [("k8s", self.listed_at), ("git", self.resolved_at)]
+            .into_iter()
+            .filter_map(|(side, at)| {
+                at.map(|at| {
+                    format!(
+                        "{} {} ago",
+                        side,
+                        short_duration(at.elapsed().as_secs() as i64)
+                    )
+                })
+            })
+            .collect();
+
+        parts.join(" · ")
+    }
+
+    pub fn matching_namespaces(&self) -> usize {
+        self.ordered_indices().len()
+    }
+
+    // ------------------------------------------------------------------------ verdicts
 
     pub fn remote(&self, namespace: &str) -> Option<&RemoteState> {
-        self.current_remotes()?.get(namespace)
+        self.remotes.get(&self.mode)?.get(namespace)
     }
 
-    pub fn container_status(&self, namespace: &str, container: &MyContainer) -> CommitStatus {
-        commit_status(container.image_ref().as_ref(), self.remote(namespace))
+    pub fn container_verdict(&self, namespace: &str, container: &MyContainer) -> Verdict {
+        judge(container.image_ref().as_ref(), self.remote(namespace))
     }
 
-    pub fn pod_status(&self, namespace: &str, pod: &MyPod) -> CommitStatus {
-        CommitStatus::worst_judged(
+    pub fn pod_verdict(&self, namespace: &str, pod: &MyPod) -> Verdict {
+        if pod.finished {
+            return Verdict::Unknown(Unresolved::Finished);
+        }
+
+        Verdict::of_parts(
             pod.containers
                 .iter()
-                .map(|container| self.container_status(namespace, container)),
+                .map(|container| self.container_verdict(namespace, container)),
         )
     }
 
-    pub fn namespace_status(&self, entry: &NamespaceEntry) -> CommitStatus {
-        if entry.error.is_some() {
-            return CommitStatus::Unknown;
+    pub fn namespace_verdict(&self, entry: &Entry) -> Verdict {
+        match &entry.pods {
+            PodsState::Failed(_) => Verdict::Failed(Failure::Kube),
+            PodsState::Listing => Verdict::Resolving,
+            PodsState::Ready(pods) if pods.is_empty() => self.reference_verdict(&entry.name),
+            PodsState::Ready(pods) => {
+                Verdict::of_parts(pods.iter().map(|pod| self.pod_verdict(&entry.name, pod)))
+            }
+        }
+    }
+
+    /// Verdict a namespace gets from its repository alone, used when there are no pods to
+    /// judge.
+    fn reference_verdict(&self, namespace: &str) -> Verdict {
+        match self.remote(namespace) {
+            Some(RemoteState::Ready(_)) => Verdict::Unknown(Unresolved::Empty),
+            other => judge(None, other),
+        }
+    }
+
+    // ------------------------------------------------------------------------ view rows
+
+    pub fn overview_rows(&self) -> Vec<NsRow> {
+        let names = self.names();
+
+        self.ordered_indices()
+            .into_iter()
+            .map(|index| self.ns_row(index, &names))
+            .collect()
+    }
+
+    /// The selected namespace as the tables show it.
+    pub fn selected_row(&self) -> Option<NsRow> {
+        let pick = self.ns_pick.as_deref()?;
+        let index = self.entries.iter().position(|entry| entry.name == pick)?;
+
+        Some(self.ns_row(index, &self.names()))
+    }
+
+    /// The same namespaces, grouped by family, the way the detail screen lists them. The
+    /// heading carries the whole prefix the family shares, so the rows below it do not have
+    /// to repeat it.
+    pub fn mini_rows(&self) -> Vec<MiniRow> {
+        let mut rows: Vec<MiniRow> = vec![];
+        let mut family: Option<String> = None;
+
+        let names = self.names();
+
+        for index in self.family_order() {
+            let row = self.ns_row(index, &names);
+            let label = family_label(shared_prefix(&row.name, &names));
+
+            if family.as_deref() != Some(label.as_str()) {
+                rows.push(MiniRow::Family(label.clone()));
+                family = Some(label);
+            }
+
+            rows.push(MiniRow::Namespace(row));
         }
 
-        CommitStatus::combined(
-            entry
-                .pods
-                .iter()
-                .map(|pod| self.pod_status(&entry.name, pod)),
-        )
+        rows
     }
 
-    /// Picks up whatever background lookups have finished since the last call. Results
-    /// are filed under the mode they were requested in, which may no longer be current.
-    pub fn drain_lookups(&mut self) {
-        loop {
-            let (mode, name, state) = match self.lookups.try_recv() {
-                Ok((mode, name, Ok(target))) => (mode, name, RemoteState::Ready(target)),
-                Ok((mode, name, Err(e))) => (mode, name, RemoteState::Failed(e.details)),
-                Err(TryRecvError::Empty) | Err(TryRecvError::Disconnected) => break,
+    /// Where the cursor sits among the rows of the detail screen's namespace list, which
+    /// also holds unselectable family headings.
+    pub fn mini_selected(&self) -> Option<usize> {
+        let pick = self.ns_pick.as_deref()?;
+
+        self.mini_rows().iter().position(|row| match row {
+            MiniRow::Namespace(ns) => ns.name == pick,
+            MiniRow::Family(_) => false,
+        })
+    }
+
+    pub fn pod_rows(&self) -> Vec<PodRow> {
+        let Some(entry) = self.selected_entry() else {
+            return vec![];
+        };
+        let now = Utc::now();
+
+        entry
+            .pod_list()
+            .iter()
+            .map(|pod| {
+                let parts = split_pod_name(&pod.name, &entry.name);
+
+                PodRow {
+                    prefix: parts.prefix.to_string(),
+                    replicaset: parts.replicaset.to_string(),
+                    suffix: parts.suffix.to_string(),
+                    verdict: self.pod_verdict(&entry.name, pod),
+                    reference: self
+                        .pod_reference(&entry.name, pod)
+                        .map(|r| r.label())
+                        .unwrap_or_else(|| MISSING.to_string()),
+                    status: pod.status.clone(),
+                    restarts: pod.restarts,
+                    age: pod.age(now).unwrap_or_else(|| MISSING.to_string()),
+                    readiness: pod.readiness(),
+                }
+            })
+            .collect()
+    }
+
+    pub fn container_rows(&self) -> Vec<ContainerRow> {
+        let Some(entry) = self.selected_entry() else {
+            return vec![];
+        };
+        let Some(pod) = self.selected_pod() else {
+            return vec![];
+        };
+
+        pod.containers
+            .iter()
+            .map(|container| {
+                let verdict = match pod.finished {
+                    true => Verdict::Unknown(Unresolved::Finished),
+                    false => self.container_verdict(&entry.name, container),
+                };
+
+                ContainerRow {
+                    name: container.name.clone(),
+                    tag: container
+                        .tag()
+                        .map(str::to_string)
+                        .unwrap_or_else(|| MISSING.to_string()),
+                    verdict,
+                    why: self.explain(&entry.name, verdict),
+                }
+            })
+            .collect()
+    }
+
+    fn ns_row(&self, index: usize, names: &[String]) -> NsRow {
+        let entry = &self.entries[index];
+        let (deployed, hidden_deployed) = self.deployed(entry);
+
+        NsRow {
+            prefix: shared_prefix(&entry.name, names).chars().count(),
+            name: entry.name.clone(),
+            verdict: self.namespace_verdict(entry),
+            pods: match &entry.pods {
+                PodsState::Ready(pods) => Some(pods.len()),
+                _ => None,
+            },
+            deployed,
+            hidden_deployed,
+            reference: self.reference_label(&entry.name),
+            note: self.note_for(entry),
+        }
+    }
+
+    /// What the pods of a namespace are running, grouped. A pod nobody can judge is left
+    /// out — somebody else's workload sharing the namespace is not a second version of
+    /// ours — but only while another pod can be judged: when none can, showing what they
+    /// run is all the column has to offer.
+    fn deployed(&self, entry: &Entry) -> (Vec<Deployed>, usize) {
+        let mut groups: Vec<Deployed> = vec![];
+        let judged = entry
+            .pod_list()
+            .iter()
+            .any(|pod| !matches!(self.pod_verdict(&entry.name, pod), Verdict::Unknown(_)));
+
+        for pod in entry.pod_list() {
+            let Some(label) = self.pod_reference(&entry.name, pod).map(|r| r.label()) else {
+                continue;
             };
+            let verdict = self.pod_verdict(&entry.name, pod);
 
-            self.remotes.entry(mode).or_default().insert(name, state);
+            if judged && matches!(verdict, Verdict::Unknown(_)) {
+                continue;
+            }
+
+            match groups.iter_mut().find(|group| group.label == label) {
+                Some(group) => {
+                    group.count += 1;
+                    group.verdict = Verdict::of_parts([group.verdict, verdict]);
+                }
+                None => groups.push(Deployed {
+                    label,
+                    count: 1,
+                    verdict,
+                }),
+            }
+        }
+
+        groups.sort_by(|a, b| b.count.cmp(&a.count).then(a.label.cmp(&b.label)));
+        let hidden = groups.len().saturating_sub(DEPLOYED_GROUPS);
+        groups.truncate(DEPLOYED_GROUPS);
+
+        (groups, hidden)
+    }
+
+    /// Reference a pod stands for: the one of its containers that says the most about the
+    /// release. Taking the first container instead would let a service mesh proxy injected
+    /// ahead of the application speak for the whole pod.
+    ///
+    /// A pod where nothing can speak — a foreign workload, or one pinned by digest — stands
+    /// for nothing, and saying so beats naming a version that means something else entirely.
+    fn pod_reference(&self, namespace: &str, pod: &MyPod) -> Option<ImageRef> {
+        let remote = self.remote(namespace);
+
+        pod.containers
+            .iter()
+            .filter_map(|container| {
+                let image_ref = container.image_ref()?;
+                let rank = reference_rank(judge(Some(&image_ref), remote))?;
+
+                Some((rank, image_ref))
+            })
+            .min_by_key(|(rank, _)| *rank)
+            .map(|(_, image_ref)| image_ref)
+    }
+
+    /// What every namespace's pods carry, when they all carry the same kind of reference.
+    pub fn deployed_kind(&self) -> RefKind {
+        self.kind_of(self.entries.iter())
+    }
+
+    /// The same for the selected namespace alone.
+    pub fn selected_kind(&self) -> RefKind {
+        self.kind_of(self.selected_entry().into_iter())
+    }
+
+    fn kind_of<'a>(&self, entries: impl Iterator<Item = &'a Entry>) -> RefKind {
+        let mut tags = false;
+        let mut commits = false;
+
+        for entry in entries {
+            for pod in entry.pod_list() {
+                match self.pod_reference(&entry.name, pod) {
+                    Some(ImageRef::Tag(_)) => tags = true,
+                    Some(ImageRef::Commit(_)) => commits = true,
+                    None => (),
+                }
+            }
+        }
+
+        match (tags, commits) {
+            (true, false) => RefKind::Tags,
+            (false, true) => RefKind::Commits,
+            (true, true) => RefKind::Mixed,
+            // nothing has arrived yet: name the column after what the mode expects
+            (false, false) => match self.mode {
+                Mode::Commit => RefKind::Commits,
+                Mode::Tag => RefKind::Tags,
+            },
         }
     }
 
-    pub fn move_selection(&mut self, delta: isize) {
-        let len = self.list_len();
-        if len == 0 {
-            return;
+    pub fn reference_label(&self, namespace: &str) -> String {
+        match self.remote(namespace) {
+            Some(RemoteState::Ready(target)) => {
+                target.name.clone().unwrap_or_else(|| target.short())
+            }
+            None | Some(RemoteState::Loading) => "resolving…".to_string(),
+            _ => MISSING.to_string(),
         }
+    }
 
-        let state = match self.focus {
-            Focus::Namespaces => &mut self.ns_state,
-            Focus::Pods => &mut self.pod_state,
-            Focus::Containers => &mut self.cont_state,
+    /// What the pods of the selected namespace are compared against, spelled out for the
+    /// header of the detail screen.
+    pub fn reference_detail(&self) -> (String, String) {
+        let Some(entry) = self.selected_entry() else {
+            return (MISSING.to_string(), String::new());
         };
 
-        let current = state.selected().unwrap_or(0) as isize;
-        let next = current.saturating_add(delta).clamp(0, len as isize - 1) as usize;
-        state.select(Some(next));
-
-        match self.focus {
-            Focus::Namespaces => self.reset_pods(),
-            Focus::Pods => self.reset_containers(),
-            Focus::Containers => (),
+        match self.remote(&entry.name) {
+            Some(RemoteState::Ready(target)) => (
+                target.label(),
+                match self.mode {
+                    Mode::Commit => "tip of the default branch".to_string(),
+                    Mode::Tag => "latest version tag".to_string(),
+                },
+            ),
+            Some(RemoteState::Loading) | None => ("resolving…".to_string(), String::new()),
+            Some(RemoteState::Unconfigured) => (
+                MISSING.to_string(),
+                "namespace has no entry in repos.json".to_string(),
+            ),
+            Some(RemoteState::NoTags) => (
+                MISSING.to_string(),
+                "repository has no tags yet".to_string(),
+            ),
+            Some(RemoteState::Failed(reason)) => (MISSING.to_string(), reason.clone()),
         }
     }
 
-    pub fn focus_next(&mut self) {
-        self.focus = match self.focus {
-            Focus::Namespaces => Focus::Pods,
-            Focus::Pods => Focus::Containers,
-            Focus::Containers => Focus::Containers,
-        };
+    pub fn repo_url(&self, namespace: &str) -> Option<&str> {
+        Some(self.repos.get_repo_by_name(namespace)?.url.as_str())
     }
 
-    pub fn focus_prev(&mut self) {
-        self.focus = match self.focus {
-            Focus::Namespaces => Focus::Namespaces,
-            Focus::Pods => Focus::Namespaces,
-            Focus::Containers => Focus::Pods,
-        };
-    }
+    fn note_for(&self, entry: &Entry) -> String {
+        match &entry.pods {
+            PodsState::Listing => "listing pods…".to_string(),
+            PodsState::Failed(reason) => format!("cannot list pods · {}", reason),
+            PodsState::Ready(pods) => match self.namespace_verdict(entry) {
+                Verdict::Behind => {
+                    let behind = pods
+                        .iter()
+                        .filter(|pod| self.pod_verdict(&entry.name, pod) == Verdict::Behind)
+                        .count();
+                    let (groups, hidden) = self.deployed(entry);
+                    // the deployed column already shows the split; the word only names it
+                    let mixed = match groups.len() + hidden > 1 {
+                        true => " · mixed",
+                        false => "",
+                    };
 
-    /// Enter: walks right through the panes, opens the commit on the last one.
-    pub fn activate(&mut self) {
-        match self.focus {
-            Focus::Namespaces | Focus::Pods => self.focus_next(),
-            Focus::Containers => self.open_selected(),
+                    format!("{} of {} pods behind{}", behind, pods.len(), mixed)
+                }
+                Verdict::Failed(_) => match self.remote(&entry.name) {
+                    Some(RemoteState::Failed(reason)) => format!("git · {}", reason),
+                    _ => "git ls-remote failed".to_string(),
+                },
+                Verdict::Resolving => "git ls-remote in flight".to_string(),
+                verdict @ Verdict::Unknown(Unresolved::Finished) => {
+                    format!("{} · no running pods", verdict.code())
+                }
+                verdict @ Verdict::Unknown(reason) => {
+                    format!("{} · {}", verdict.code(), reason_text(reason))
+                }
+                Verdict::InSync => String::new(),
+            },
         }
     }
 
-    pub fn refresh_selected(&mut self) {
-        let Some(entry) = self.selected_namespace() else {
-            return;
-        };
-        let name = entry.name.clone();
-
-        // a second request would spawn another thread and could land out of order,
-        // overwriting the newer answer with the older one
-        if matches!(self.remote(&name), Some(RemoteState::Loading)) {
-            return;
+    /// Plain words for a container's verdict — the answer to "why is this row grey".
+    fn explain(&self, namespace: &str, verdict: Verdict) -> String {
+        match verdict {
+            Verdict::InSync => format!("matches {}", self.reference_label(namespace)),
+            Verdict::Behind => format!("behind · reference is {}", self.reference_label(namespace)),
+            Verdict::Resolving => "resolving the reference".to_string(),
+            Verdict::Failed(_) => match self.remote(namespace) {
+                Some(RemoteState::Failed(reason)) => reason.clone(),
+                _ => "lookup failed".to_string(),
+            },
+            Verdict::Unknown(reason) => format!("{} · {}", verdict.code(), reason_text(reason)),
         }
-
-        self.request(&name);
-        self.status.clear();
     }
 
-    /// Why the selected namespace cannot be judged, if that is the case — the reason is
-    /// otherwise recorded but never shown.
-    fn selected_problem(&self) -> Option<String> {
-        let entry = self.selected_namespace()?;
+    // -------------------------------------------------------------------------- footer
 
-        if let Some(error) = &entry.error {
-            return Some(format!("{}: {}", entry.name, error));
+    /// What the footer says: the last action, or why the selected namespace cannot be
+    /// judged. Actions expire, standing problems do not.
+    pub fn note(&self) -> Option<Note> {
+        if let Some(note) = self.reported() {
+            return Some(Note {
+                kind: note.kind,
+                text: note.text.clone(),
+                retry: note.retry,
+                standing: false,
+            });
+        }
+
+        let entry = self.selected_entry()?;
+
+        if let PodsState::Failed(reason) = &entry.pods {
+            return Some(Note {
+                kind: NoteKind::Error,
+                text: format!("{} · cannot list pods: {}", entry.name, reason),
+                retry: true,
+                standing: true,
+            });
         }
 
         match self.remote(&entry.name) {
-            Some(RemoteState::Failed(reason)) => Some(format!("{}: {}", entry.name, reason)),
+            Some(RemoteState::Failed(reason)) => Some(Note {
+                kind: NoteKind::Error,
+                text: format!("{} · git ls-remote: {}", entry.name, reason),
+                retry: true,
+                standing: true,
+            }),
+            Some(RemoteState::Unconfigured) => Some(Note {
+                kind: NoteKind::Warn,
+                text: format!(
+                    "{} is missing in repos.json — nothing to compare",
+                    entry.name
+                ),
+                retry: false,
+                standing: true,
+            }),
+            Some(RemoteState::NoTags) => Some(Note {
+                kind: NoteKind::Warn,
+                text: format!(
+                    "{} has no tags — try {} mode",
+                    entry.name,
+                    self.mode.toggled().label()
+                ),
+                retry: false,
+                standing: true,
+            }),
             _ => None,
         }
     }
 
-    fn open_selected(&mut self) {
-        let Some(entry) = self.selected_namespace() else {
+    /// The reported action, while it is still worth showing.
+    fn reported(&self) -> Option<&Note> {
+        self.note
+            .as_ref()
+            .filter(|(_, at)| at.elapsed() < NOTE_TTL)
+            .map(|(note, _)| note)
+    }
+
+    /// Gives up the reported action. An expired one is already invisible, so giving it up
+    /// must not count as having done something — Esc would be swallowed for nothing.
+    pub fn dismiss_note(&mut self) -> bool {
+        let showing = self.reported().is_some();
+        self.note = None;
+
+        showing
+    }
+
+    /// One line about the selected container, shown on the detail screen.
+    pub fn selection_summary(&self) -> Option<String> {
+        let entry = self.selected_entry()?;
+        let container = self.selected_container()?;
+        let verdict = self.container_verdict(&entry.name, container);
+        let running = container
+            .tag()
+            .map(str::to_string)
+            .unwrap_or_else(|| MISSING.to_string());
+
+        Some(match verdict {
+            Verdict::Behind => format!(
+                "{} runs {} → reference is {}",
+                container.name,
+                running,
+                self.reference_label(&entry.name)
+            ),
+            Verdict::InSync => format!("{} runs the reference {}", container.name, running),
+            _ => format!(
+                "{} {} · {}",
+                container.name,
+                running,
+                self.explain(&entry.name, verdict)
+            ),
+        })
+    }
+
+    // ------------------------------------------------------------------------ selection
+
+    pub fn selected_entry(&self) -> Option<&Entry> {
+        let pick = self.ns_pick.as_deref()?;
+
+        self.entries.iter().find(|entry| entry.name == pick)
+    }
+
+    pub fn selected_pod(&self) -> Option<&MyPod> {
+        let pick = self.pod_pick.as_deref()?;
+
+        self.selected_entry()?
+            .pod_list()
+            .iter()
+            .find(|pod| pod.name == pick)
+    }
+
+    pub fn selected_container(&self) -> Option<&MyContainer> {
+        let pick = self.cont_pick.as_deref()?;
+
+        self.selected_pod()?
+            .containers
+            .iter()
+            .find(|container| container.name == pick)
+    }
+
+    pub fn ns_state(&mut self) -> &mut TableState {
+        &mut self.ns_state
+    }
+
+    pub fn pod_state(&mut self) -> &mut TableState {
+        &mut self.pod_state
+    }
+
+    pub fn cont_state(&mut self) -> &mut TableState {
+        &mut self.cont_state
+    }
+
+    pub fn ns_position(&self) -> Option<usize> {
+        let pick = self.ns_pick.as_deref()?;
+
+        self.ordered_names().iter().position(|name| name == pick)
+    }
+
+    pub fn pod_position(&self) -> Option<usize> {
+        let pick = self.pod_pick.as_deref()?;
+
+        self.selected_entry()?
+            .pod_list()
+            .iter()
+            .position(|pod| pod.name == pick)
+    }
+
+    pub fn container_position(&self) -> Option<usize> {
+        let pick = self.cont_pick.as_deref()?;
+
+        self.selected_pod()?
+            .containers
+            .iter()
+            .position(|container| container.name == pick)
+    }
+
+    pub fn move_selection(&mut self, delta: isize) {
+        let rows = self.active_rows();
+        if rows.is_empty() {
+            return;
+        }
+
+        let current = self
+            .active_pick()
+            .and_then(|pick| rows.iter().position(|row| *row == pick))
+            .unwrap_or(0) as isize;
+        let next = current
+            .saturating_add(delta)
+            .clamp(0, rows.len() as isize - 1) as usize;
+
+        self.set_active_pick(rows[next].clone());
+    }
+
+    pub fn focus_next(&mut self) {
+        self.pane = match self.pane {
+            Pane::Namespaces => Pane::Pods,
+            Pane::Pods | Pane::Containers => Pane::Containers,
+        };
+    }
+
+    pub fn focus_prev(&mut self) {
+        self.pane = match self.pane {
+            Pane::Namespaces | Pane::Pods => Pane::Namespaces,
+            Pane::Containers => Pane::Pods,
+        };
+    }
+
+    pub fn focus_containers(&mut self) {
+        self.pane = Pane::Containers;
+    }
+
+    /// Enter: the overview opens a namespace, the detail screen opens a commit.
+    pub fn activate(&mut self) {
+        match self.screen {
+            Screen::Overview => self.open_namespace(),
+            Screen::Detail => self.open_commit(),
+        }
+    }
+
+    pub fn open_namespace(&mut self) {
+        if self.ns_pick.is_none() {
+            return;
+        }
+
+        self.screen = Screen::Detail;
+        self.pane = Pane::Pods;
+    }
+
+    /// Esc: gives up whatever is on top — a message, then the detail screen, then the tool.
+    pub fn back(&mut self) {
+        if self.dismiss_note() {
+            return;
+        }
+
+        match self.screen {
+            Screen::Detail => {
+                self.screen = Screen::Overview;
+                self.pane = Pane::Pods;
+            }
+            Screen::Overview => self.quit(),
+        }
+    }
+
+    // ------------------------------------------------------------------------- commands
+
+    /// Switching modes reuses whatever was already resolved and only asks for the rest.
+    pub fn toggle_mode(&mut self) {
+        self.mode = self.mode.toggled();
+        self.note = None;
+        self.request_missing();
+    }
+
+    pub fn cycle_filter(&mut self) {
+        self.filter = self.filter.next();
+    }
+
+    pub fn cycle_sort(&mut self) {
+        self.sort = self.sort.next();
+    }
+
+    /// Search filters the namespace list, so it is only allowed while that list is the one
+    /// the user is looking at — filtering a list that is off screen would move the selection
+    /// under them.
+    pub fn start_search(&mut self) {
+        if self.searchable() {
+            self.input = Input::Search;
+        }
+    }
+
+    pub fn searchable(&self) -> bool {
+        match self.screen {
+            Screen::Overview => true,
+            Screen::Detail => self.pane == Pane::Namespaces && !self.narrow,
+        }
+    }
+
+    pub fn search_push(&mut self, symbol: char) {
+        self.query.push(symbol);
+    }
+
+    pub fn search_pop(&mut self) {
+        self.query.pop();
+    }
+
+    /// Leaving search either keeps the typed filter or drops it.
+    pub fn end_search(&mut self, keep: bool) {
+        self.input = Input::Normal;
+
+        if !keep {
+            self.query.clear();
+        }
+    }
+
+    pub fn toggle_help(&mut self) {
+        self.input = match self.input {
+            Input::Help => Input::Normal,
+            _ => Input::Help,
+        };
+    }
+
+    /// Asks the selected namespace again — `git` for its reference, and Kubernetes for its
+    /// pods when that is the side that failed. The footer offers `r` for both, so both have
+    /// to happen.
+    pub fn refresh_selected(&mut self) {
+        let Some(entry) = self.selected_entry() else {
+            return;
+        };
+        let name = entry.name.clone();
+        let unlisted = matches!(entry.pods, PodsState::Failed(_));
+
+        if unlisted {
+            // the round stays as it is: nothing is in flight for a namespace that failed,
+            // and bumping it would throw away the answers still coming for the others
+            let round = self.listing_round;
+
+            if let Some(entry) = self.entries.iter_mut().find(|entry| entry.name == name) {
+                entry.pods = PodsState::Listing;
+            }
+
+            self.spawn_listing(round, name.clone());
+        }
+
+        // a second request would spawn another thread and could land out of order,
+        // overwriting the newer answer with the older one
+        if !matches!(self.remote(&name), Some(RemoteState::Loading)) {
+            self.request(&name);
+        }
+
+        self.note = None;
+    }
+
+    /// Asks Kubernetes for the pods of every namespace again.
+    pub fn relist_pods(&mut self) {
+        self.listing_round += 1;
+        let round = self.listing_round;
+
+        for entry in &mut self.entries {
+            entry.pods = PodsState::Listing;
+        }
+
+        for name in self.names() {
+            self.spawn_listing(round, name);
+        }
+    }
+
+    fn spawn_listing(&self, round: u64, name: String) {
+        let tx = self.pods_tx.clone();
+        let client = self.kube.clone();
+
+        tokio::spawn(async move {
+            let pods = MyPod::get_pods_by_ns(&client, &name).await;
+            let _ = tx.send((round, name, pods));
+        });
+    }
+
+    fn open_commit(&mut self) {
+        let Some(entry) = self.selected_entry() else {
             return;
         };
         let namespace = entry.name.clone();
 
-        let Some(container) = self.selected_container() else {
-            self.status = "No container selected".to_string();
-            return;
+        let image_ref = match self.pane {
+            Pane::Containers => self.selected_container().and_then(|c| c.image_ref()),
+            _ => self
+                .selected_pod()
+                .and_then(|pod| self.pod_reference(&namespace, pod)),
         };
-        let image = container.short_image().to_string();
 
-        let Some(image_ref) = container.image_ref() else {
-            self.status = format!("{}: image carries no tag", image);
+        let Some(image_ref) = image_ref else {
+            self.report(NoteKind::Warn, "nothing here carries a commit".to_string());
             return;
         };
 
@@ -320,31 +1166,49 @@ impl App {
         };
 
         let Some(hash) = hash else {
-            self.status = format!(
-                "{}: cannot resolve {} to a commit — try {} mode",
-                image,
-                image_ref.as_str(),
-                self.mode.toggled().label()
+            self.report(
+                NoteKind::Warn,
+                format!(
+                    "cannot resolve {} to a commit — try {} mode",
+                    image_ref.as_str(),
+                    self.mode.toggled().label()
+                ),
             );
             return;
         };
 
-        let Some(repo) = self.repos.get_repo_by_name(&namespace) else {
-            self.status = format!("{} is missing in repos.json", namespace);
+        let Some(url) = self.repo_url(&namespace).map(str::to_string) else {
+            self.report(
+                NoteKind::Warn,
+                format!("{} is missing in repos.json", namespace),
+            );
             return;
         };
-        let url = repo.url.clone();
 
-        self.status = match open_with_hash(&url, &hash) {
-            Ok(_) => format!("Opened {}", commit_url(&url, &hash)),
-            Err(e) => format!("Cannot open browser: {}", e),
-        };
+        match open_with_hash(&url, &hash) {
+            Ok(_) => self.report(NoteKind::Ok, format!("opened {}", commit_url(&url, &hash))),
+            Err(e) => self.report(NoteKind::Error, format!("cannot open browser: {}", e)),
+        }
     }
+
+    fn report(&mut self, kind: NoteKind, text: String) {
+        self.note = Some((
+            Note {
+                kind,
+                text,
+                retry: false,
+                standing: false,
+            },
+            Instant::now(),
+        ));
+    }
+
+    // -------------------------------------------------------------- background plumbing
 
     /// Asks for every namespace the current mode has no answer for yet.
     fn request_missing(&mut self) {
         let pending: Vec<String> = self
-            .namespaces
+            .entries
             .iter()
             .map(|entry| entry.name.clone())
             .filter(|name| self.remote(name).is_none())
@@ -362,19 +1226,47 @@ impl App {
             Some(repo) => {
                 let url = repo.url.clone();
                 self.set_remote(namespace, RemoteState::Loading);
-                spawn_lookup(self.tx.clone(), mode, namespace.to_string(), url);
+                spawn_lookup(self.lookups_tx.clone(), mode, namespace.to_string(), url);
             }
-            None => {
-                self.set_remote(
-                    namespace,
-                    RemoteState::Failed("missing in repos.json".to_string()),
-                );
-            }
+            None => self.set_remote(namespace, RemoteState::Unconfigured),
         }
     }
 
-    fn current_remotes(&self) -> Option<&HashMap<String, RemoteState>> {
-        self.remotes.get(&self.mode)
+    fn drain_lookups(&mut self) {
+        while let Ok((mode, name, result)) = self.lookups_rx.try_recv() {
+            let state = match result {
+                Ok(target) => RemoteState::Ready(target),
+                Err(LookupError::NoTags) => RemoteState::NoTags,
+                Err(LookupError::Git(reason)) => RemoteState::Failed(reason),
+            };
+
+            self.remotes.entry(mode).or_default().insert(name, state);
+            self.resolved_at = Some(Instant::now());
+        }
+    }
+
+    fn drain_pods(&mut self) {
+        while let Ok((round, name, result)) = self.pods_rx.try_recv() {
+            self.accept_pods(round, &name, result);
+        }
+    }
+
+    fn accept_pods(&mut self, round: u64, name: &str, result: Result<Vec<MyPod>, MsgError>) {
+        // an answer from an earlier round would put a stale list of pods back on screen
+        if round != self.listing_round {
+            return;
+        }
+
+        let state = match result {
+            Ok(pods) => PodsState::Ready(pods),
+            Err(e) => PodsState::Failed(e.details),
+        };
+
+        if let Some(entry) = self.entries.iter_mut().find(|entry| entry.name == name) {
+            entry.pods = state;
+        }
+
+        self.listed_at = Some(Instant::now());
     }
 
     fn set_remote(&mut self, namespace: &str, state: RemoteState) {
@@ -384,26 +1276,717 @@ impl App {
             .insert(namespace.to_string(), state);
     }
 
-    fn list_len(&self) -> usize {
-        match self.focus {
-            Focus::Namespaces => self.namespaces.len(),
-            Focus::Pods => self.selected_namespace().map_or(0, |ns| ns.pods.len()),
-            Focus::Containers => self.selected_pod().map_or(0, |p| p.containers.len()),
+    // ------------------------------------------------------------------------- ordering
+
+    /// Namespaces the current filter and search leave, in the order of the active screen.
+    fn ordered_indices(&self) -> Vec<usize> {
+        match self.screen {
+            Screen::Overview => self.sorted_order(),
+            Screen::Detail => self.family_order(),
         }
     }
 
-    fn reset_pods(&mut self) {
-        let has_pods = self
-            .selected_namespace()
-            .is_some_and(|ns| !ns.pods.is_empty());
-        self.pod_state.select(has_pods.then_some(0));
-        self.reset_containers();
+    fn names(&self) -> Vec<String> {
+        self.entries.iter().map(|e| e.name.clone()).collect()
     }
 
-    fn reset_containers(&mut self) {
-        let has_containers = self
+    fn ordered_names(&self) -> Vec<String> {
+        self.ordered_indices()
+            .into_iter()
+            .map(|index| self.entries[index].name.clone())
+            .collect()
+    }
+
+    fn visible_indices(&self) -> Vec<usize> {
+        let query = self.query.to_lowercase();
+
+        self.entries
+            .iter()
+            .enumerate()
+            .filter(|(_, entry)| entry.name.to_lowercase().contains(&query))
+            .filter(|(_, entry)| self.filter.accepts(self.namespace_verdict(entry)))
+            .map(|(index, _)| index)
+            .collect()
+    }
+
+    fn sorted_order(&self) -> Vec<usize> {
+        let mut indices = self.visible_indices();
+
+        indices.sort_by(|a, b| {
+            let (left, right) = (&self.entries[*a], &self.entries[*b]);
+
+            match self.sort {
+                Sort::Status => self
+                    .namespace_verdict(left)
+                    .severity()
+                    .cmp(&self.namespace_verdict(right).severity())
+                    .then(left.name.cmp(&right.name)),
+                Sort::Name => left.name.cmp(&right.name),
+                Sort::Pods => right
+                    .pod_list()
+                    .len()
+                    .cmp(&left.pod_list().len())
+                    .then(left.name.cmp(&right.name)),
+            }
+        });
+
+        indices
+    }
+
+    /// Grouped by the family a namespace belongs to, worst first inside a family.
+    fn family_order(&self) -> Vec<usize> {
+        let names = self.names();
+        let mut indices = self.visible_indices();
+
+        indices.sort_by(|a, b| {
+            let (left, right) = (&self.entries[*a], &self.entries[*b]);
+            let left_family = family_prefix(&left.name, &names);
+            let right_family = family_prefix(&right.name, &names);
+
+            // families in alphabetical order, the unfamilied ones last
+            left_family
+                .is_empty()
+                .cmp(&right_family.is_empty())
+                .then(left_family.cmp(right_family))
+                .then(
+                    self.namespace_verdict(left)
+                        .severity()
+                        .cmp(&self.namespace_verdict(right).severity()),
+                )
+                .then(left.name.cmp(&right.name))
+        });
+
+        indices
+    }
+
+    fn active_rows(&self) -> Vec<String> {
+        match (self.screen, self.pane) {
+            (Screen::Overview, _) | (Screen::Detail, Pane::Namespaces) => self.ordered_names(),
+            (Screen::Detail, Pane::Pods) => self
+                .selected_entry()
+                .map(|entry| entry.pod_list().iter().map(|p| p.name.clone()).collect())
+                .unwrap_or_default(),
+            (Screen::Detail, Pane::Containers) => self
+                .selected_pod()
+                .map(|pod| pod.containers.iter().map(|c| c.name.clone()).collect())
+                .unwrap_or_default(),
+        }
+    }
+
+    fn active_pick(&self) -> Option<String> {
+        match (self.screen, self.pane) {
+            (Screen::Overview, _) | (Screen::Detail, Pane::Namespaces) => self.ns_pick.clone(),
+            (Screen::Detail, Pane::Pods) => self.pod_pick.clone(),
+            (Screen::Detail, Pane::Containers) => self.cont_pick.clone(),
+        }
+    }
+
+    fn set_active_pick(&mut self, pick: String) {
+        match (self.screen, self.pane) {
+            (Screen::Overview, _) | (Screen::Detail, Pane::Namespaces) => {
+                if self.ns_pick.as_deref() != Some(pick.as_str()) {
+                    self.pod_pick = None;
+                    self.cont_pick = None;
+                }
+                self.ns_pick = Some(pick);
+            }
+            (Screen::Detail, Pane::Pods) => {
+                if self.pod_pick.as_deref() != Some(pick.as_str()) {
+                    self.cont_pick = None;
+                }
+                self.pod_pick = Some(pick);
+            }
+            (Screen::Detail, Pane::Containers) => self.cont_pick = Some(pick),
+        }
+    }
+
+    /// Keeps every cursor on a row that exists, which matters because rows arrive, get
+    /// filtered out and get reordered while the tool is open.
+    fn normalize(&mut self) {
+        let names = self.ordered_names();
+        if !names
+            .iter()
+            .any(|name| self.ns_pick.as_deref() == Some(name))
+        {
+            self.ns_pick = names.first().cloned();
+            self.pod_pick = None;
+            self.cont_pick = None;
+        }
+
+        let pods: Vec<String> = self
+            .selected_entry()
+            .map(|entry| entry.pod_list().iter().map(|p| p.name.clone()).collect())
+            .unwrap_or_default();
+        if !pods
+            .iter()
+            .any(|name| self.pod_pick.as_deref() == Some(name))
+        {
+            self.pod_pick = pods.first().cloned();
+            self.cont_pick = None;
+        }
+
+        let containers: Vec<String> = self
             .selected_pod()
-            .is_some_and(|pod| !pod.containers.is_empty());
-        self.cont_state.select(has_containers.then_some(0));
+            .map(|pod| pod.containers.iter().map(|c| c.name.clone()).collect())
+            .unwrap_or_default();
+        if !containers
+            .iter()
+            .any(|name| self.cont_pick.as_deref() == Some(name))
+        {
+            self.cont_pick = containers.first().cloned();
+        }
+    }
+}
+
+fn family_label(prefix: &str) -> String {
+    match prefix.trim_end_matches('-') {
+        "" => "other".to_string(),
+        family => family.to_string(),
+    }
+}
+
+/// How much a container's reference is worth as the pod's: one that could be compared beats
+/// one still being looked up, which beats one this mode cannot resolve at all. `None` for a
+/// container that says nothing about this repository.
+fn reference_rank(verdict: Verdict) -> Option<u8> {
+    match verdict {
+        Verdict::InSync | Verdict::Behind => Some(0),
+        Verdict::Resolving | Verdict::Failed(_) => Some(1),
+        Verdict::Unknown(Unresolved::WrongMode) => Some(2),
+        Verdict::Unknown(_) => None,
+    }
+}
+
+fn reason_text(reason: Unresolved) -> &'static str {
+    match reason {
+        Unresolved::Sidecar => "not built from this repository",
+        Unresolved::Digest => "image carries no commit",
+        Unresolved::NoConfig => "missing in repos.json",
+        Unresolved::NoTags => "repository has no tags",
+        Unresolved::WrongMode => "commit mode cannot resolve a version — try tag mode",
+        Unresolved::Finished => "the pod has already run its course",
+        Unresolved::Empty => "no pods to compare",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::git::remote::Target;
+    use crate::storage::common::Repo;
+    use kube::Config;
+    use speculoos::prelude::*;
+
+    const GATEWAY: &str = "orchard-gateway";
+    const LEDGER: &str = "orchard-ledger-api";
+    const MAILER: &str = "tulip-mailer";
+    const LEFTOVER: &str = "91bd7e40-8103771";
+
+    fn client() -> Client {
+        Client::try_from(Config::new("http://127.0.0.1:1".parse().unwrap())).unwrap()
+    }
+
+    fn repos(names: &[&str]) -> JsonStorage {
+        JsonStorage::from_repos(
+            names
+                .iter()
+                .map(|name| Repo {
+                    name: name.to_string(),
+                    url: format!("https://git.example.com/{}", name),
+                })
+                .collect(),
+        )
+    }
+
+    fn app(names: &[&str]) -> App {
+        let mut app = App::new(
+            names.iter().map(|n| n.to_string()).collect(),
+            repos(names),
+            Mode::Commit,
+            Cluster::default(),
+            client(),
+        );
+
+        // App::new starts a real listing against an address nobody answers; moving on a
+        // round makes its eventual failures stale, so the tests decide what the state is
+        app.listing_round += 1;
+
+        app
+    }
+
+    fn pod(namespace: &str, name: &str, tag: &str) -> MyPod {
+        MyPod {
+            name: name.to_string(),
+            namespace: namespace.to_string(),
+            containers: vec![MyContainer {
+                name: "app".to_string(),
+                image: format!("registry.example/{}:{}", namespace, tag),
+            }],
+            status: "Running".to_string(),
+            restarts: 0,
+            ready: 1,
+            created: None,
+            finished: false,
+        }
+    }
+
+    /// Puts a namespace in the state it would reach after both lookups came back.
+    fn settle(app: &mut App, namespace: &str, deployed: &str, reference: &str) {
+        app.accept_pods(
+            app.listing_round,
+            namespace,
+            Ok(vec![pod(
+                namespace,
+                &format!("{}-abc12-x1y2z", namespace),
+                deployed,
+            )]),
+        );
+        app.set_remote(
+            namespace,
+            RemoteState::Ready(Target {
+                commit: reference.to_string(),
+                ..Target::default()
+            }),
+        );
+    }
+
+    fn in_sync(app: &mut App, namespace: &str) {
+        settle(
+            app,
+            namespace,
+            "4f1c0f2c-8103771",
+            "4f1c0f2c8b3d4e5a6f708192a3b4c5d6e7f80912",
+        );
+    }
+
+    fn behind(app: &mut App, namespace: &str) {
+        settle(
+            app,
+            namespace,
+            "91bd7e40-8103771",
+            "4f1c0f2c8b3d4e5a6f708192a3b4c5d6e7f80912",
+        );
+    }
+
+    /// Somebody else's workload sharing the namespace: a tag this repository never had.
+    fn foreign(namespace: &str) -> MyPod {
+        MyPod {
+            name: format!("{}-mesh-ingress-7c1b9-vd6np", namespace),
+            namespace: namespace.to_string(),
+            containers: vec![MyContainer {
+                name: "mesh-ingress".to_string(),
+                image: "registry.example/mesh-ingress:1.21".to_string(),
+            }],
+            status: "Running".to_string(),
+            restarts: 0,
+            ready: 1,
+            created: None,
+            finished: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn foreign_pod_does_not_hold_the_namespace_back() {
+        let mut app = app(&[GATEWAY]);
+        in_sync(&mut app, GATEWAY);
+        let mut pods = vec![foreign(GATEWAY)];
+        pods.push(pod(
+            GATEWAY,
+            "orchard-gateway-abc12-x1y2z",
+            "4f1c0f2c-8103771",
+        ));
+        app.accept_pods(app.listing_round, GATEWAY, Ok(pods));
+
+        asserting!("a pod that is not ours must not make the namespace unjudgeable")
+            .that(
+                &app.selected_entry()
+                    .map(|entry| app.namespace_verdict(entry)),
+            )
+            .is_equal_to(Some(Verdict::InSync));
+    }
+
+    #[tokio::test]
+    async fn foreign_pod_is_not_counted_as_a_deployed_commit() {
+        let mut app = app(&[GATEWAY]);
+        in_sync(&mut app, GATEWAY);
+        let mut pods = vec![foreign(GATEWAY)];
+        pods.push(pod(
+            GATEWAY,
+            "orchard-gateway-abc12-x1y2z",
+            "4f1c0f2c-8103771",
+        ));
+        app.accept_pods(app.listing_round, GATEWAY, Ok(pods));
+
+        asserting!("its tag would otherwise read as a second commit of ours")
+            .that(&app.overview_rows().first().map(|row| row.deployed.len()))
+            .is_equal_to(Some(1));
+    }
+
+    #[tokio::test]
+    async fn namespace_of_nothing_but_foreign_pods_says_why() {
+        let release = "9d02f4ab3c1d5e7f8091a2b3c4d5e6f708192a3b";
+        let mut app = app(&[GATEWAY]);
+        app.set_remote(
+            GATEWAY,
+            RemoteState::Ready(Target {
+                commit: release.to_string(),
+                name: Some("v3.7.1".to_string()),
+                tags: HashMap::from([("v3.7.1".to_string(), release.to_string())]),
+            }),
+        );
+        app.accept_pods(app.listing_round, GATEWAY, Ok(vec![foreign(GATEWAY)]));
+
+        asserting!("the repository has tags, and this image is built from none of them")
+            .that(
+                &app.selected_entry()
+                    .map(|entry| app.namespace_verdict(entry)),
+            )
+            .is_equal_to(Some(Verdict::Unknown(Unresolved::Sidecar)));
+    }
+
+    #[tokio::test]
+    async fn release_image_in_commit_mode_says_which_mode_would_work() {
+        let mut app = app(&[GATEWAY]);
+        in_sync(&mut app, GATEWAY);
+        app.accept_pods(
+            app.listing_round,
+            GATEWAY,
+            Ok(vec![pod(
+                GATEWAY,
+                "orchard-gateway-abc12-x1y2z",
+                "v3.7.1-8203114",
+            )]),
+        );
+
+        asserting!("production runs releases, and commit mode cannot resolve one")
+            .that(
+                &app.selected_entry()
+                    .map(|entry| app.namespace_verdict(entry)),
+            )
+            .is_equal_to(Some(Verdict::Unknown(Unresolved::WrongMode)));
+    }
+
+    /// What a CronJob leaves behind: it ran an older commit and then stopped.
+    /// A pod whose service mesh proxy is injected ahead of the application.
+    fn proxied(namespace: &str, tag: &str) -> MyPod {
+        let mut running = pod(namespace, &format!("{}-abc12-x1y2z", namespace), tag);
+        running.containers.insert(
+            0,
+            MyContainer {
+                name: "mesh-proxy".to_string(),
+                image: "registry.example/mesh-proxy:1.26.2".to_string(),
+            },
+        );
+
+        running
+    }
+
+    fn finished(namespace: &str, tag: &str) -> MyPod {
+        MyPod {
+            finished: true,
+            status: "Completed".to_string(),
+            ready: 0,
+            ..pod(
+                namespace,
+                &format!("{}-cleaner-29749830-9fmrv", namespace),
+                tag,
+            )
+        }
+    }
+
+    #[tokio::test]
+    async fn pod_that_has_finished_does_not_make_the_namespace_lag() {
+        let mut app = app(&[GATEWAY]);
+        in_sync(&mut app, GATEWAY);
+        let mut pods = vec![finished(GATEWAY, LEFTOVER)];
+        pods.push(pod(
+            GATEWAY,
+            "orchard-gateway-abc12-x1y2z",
+            "4f1c0f2c-8103771",
+        ));
+        app.accept_pods(app.listing_round, GATEWAY, Ok(pods));
+
+        asserting!("it ran the code that was current then and deploys nothing now")
+            .that(
+                &app.selected_entry()
+                    .map(|entry| app.namespace_verdict(entry)),
+            )
+            .is_equal_to(Some(Verdict::InSync));
+    }
+
+    #[tokio::test]
+    async fn pod_that_has_finished_is_not_counted_as_a_deployed_commit() {
+        let mut app = app(&[GATEWAY]);
+        in_sync(&mut app, GATEWAY);
+        let mut pods = vec![finished(GATEWAY, LEFTOVER)];
+        pods.push(pod(
+            GATEWAY,
+            "orchard-gateway-abc12-x1y2z",
+            "4f1c0f2c-8103771",
+        ));
+        app.accept_pods(app.listing_round, GATEWAY, Ok(pods));
+
+        asserting!("its commit would otherwise read as a rollout that stopped half way")
+            .that(&app.overview_rows().first().map(|row| row.deployed.len()))
+            .is_equal_to(Some(1));
+    }
+
+    #[tokio::test]
+    async fn namespace_where_nothing_runs_any_more_says_so() {
+        let mut app = app(&[GATEWAY]);
+        in_sync(&mut app, GATEWAY);
+        app.accept_pods(
+            app.listing_round,
+            GATEWAY,
+            Ok(vec![finished(GATEWAY, LEFTOVER)]),
+        );
+
+        assert_that!(app
+            .selected_entry()
+            .map(|entry| app.namespace_verdict(entry)))
+        .is_equal_to(Some(Verdict::Unknown(Unresolved::Finished)));
+    }
+
+    #[tokio::test]
+    async fn pod_that_has_finished_still_shows_what_it_ran() {
+        let ran = "91bd7e40";
+        let mut app = app(&[GATEWAY]);
+        in_sync(&mut app, GATEWAY);
+        app.accept_pods(
+            app.listing_round,
+            GATEWAY,
+            Ok(vec![finished(GATEWAY, LEFTOVER)]),
+        );
+        app.tick();
+
+        asserting!("keeping it out of the verdict must not hide it")
+            .that(&app.pod_rows().first().map(|row| row.reference.clone()))
+            .is_equal_to(Some(ran.to_string()));
+    }
+
+    #[tokio::test]
+    async fn application_speaks_for_the_pod_not_the_proxy_beside_it() {
+        let running = "4f1c0f2c";
+        let mut app = app(&[GATEWAY]);
+        in_sync(&mut app, GATEWAY);
+        app.accept_pods(
+            app.listing_round,
+            GATEWAY,
+            Ok(vec![proxied(GATEWAY, "4f1c0f2c-8103771")]),
+        );
+
+        asserting!("a proxy injected first would otherwise report its own version as ours")
+            .that(
+                &app.overview_rows()
+                    .first()
+                    .map(|row| row.deployed[0].label.clone()),
+            )
+            .is_equal_to(Some(running.to_string()));
+    }
+
+    #[tokio::test]
+    async fn proxy_beside_the_application_does_not_rename_the_column() {
+        let mut app = app(&[GATEWAY]);
+        in_sync(&mut app, GATEWAY);
+        app.accept_pods(
+            app.listing_round,
+            GATEWAY,
+            Ok(vec![proxied(GATEWAY, "4f1c0f2c-8103771")]),
+        );
+
+        assert_that!(app.deployed_kind()).is_equal_to(RefKind::Commits);
+    }
+
+    #[tokio::test]
+    async fn column_is_named_after_the_commits_it_holds() {
+        let mut app = app(&[GATEWAY]);
+        in_sync(&mut app, GATEWAY);
+
+        assert_that!(app.deployed_kind()).is_equal_to(RefKind::Commits);
+    }
+
+    #[tokio::test]
+    async fn column_is_named_after_the_tags_it_holds() {
+        let mut app = app(&[GATEWAY]);
+        in_sync(&mut app, GATEWAY);
+        app.accept_pods(
+            app.listing_round,
+            GATEWAY,
+            Ok(vec![pod(
+                GATEWAY,
+                "orchard-gateway-abc12-x1y2z",
+                "v3.7.1-8203114",
+            )]),
+        );
+
+        asserting!("a cluster deployed from releases carries tags whichever mode is on")
+            .that(&app.deployed_kind())
+            .is_equal_to(RefKind::Tags);
+    }
+
+    #[tokio::test]
+    async fn column_that_holds_both_is_named_after_neither() {
+        let mut app = app(&[GATEWAY, LEDGER]);
+        in_sync(&mut app, GATEWAY);
+        in_sync(&mut app, LEDGER);
+        app.accept_pods(
+            app.listing_round,
+            LEDGER,
+            Ok(vec![pod(
+                LEDGER,
+                "orchard-ledger-api-abc12-x1y2z",
+                "v3.7.1-8203114",
+            )]),
+        );
+
+        assert_that!(app.deployed_kind()).is_equal_to(RefKind::Mixed);
+    }
+
+    #[tokio::test]
+    async fn overview_puts_what_needs_acting_on_first() {
+        let mut app = app(&[GATEWAY, LEDGER]);
+        in_sync(&mut app, GATEWAY);
+        behind(&mut app, LEDGER);
+
+        asserting!("a lagging namespace must not be found by scrolling")
+            .that(&app.overview_rows().first().map(|row| row.name.clone()))
+            .is_equal_to(Some(LEDGER.to_string()));
+    }
+
+    #[tokio::test]
+    async fn sorting_by_name_ignores_the_verdict() {
+        let mut app = app(&[MAILER, GATEWAY]);
+        behind(&mut app, MAILER);
+        in_sync(&mut app, GATEWAY);
+        app.cycle_sort();
+
+        assert_that!(app.overview_rows().first().map(|row| row.name.clone()))
+            .is_equal_to(Some(GATEWAY.to_string()));
+    }
+
+    #[tokio::test]
+    async fn problems_filter_drops_what_is_in_sync() {
+        let mut app = app(&[GATEWAY, LEDGER]);
+        in_sync(&mut app, GATEWAY);
+        behind(&mut app, LEDGER);
+        app.cycle_filter();
+
+        assert_that!(app.overview_rows().len()).is_equal_to(1);
+    }
+
+    #[tokio::test]
+    async fn search_narrows_the_list_to_what_matches() {
+        let mut app = app(&[GATEWAY, LEDGER, MAILER]);
+        app.start_search();
+        for symbol in "ledger".chars() {
+            app.search_push(symbol);
+        }
+        app.tick();
+
+        assert_that!(app.matching_namespaces()).is_equal_to(1);
+    }
+
+    #[tokio::test]
+    async fn cursor_stays_on_the_namespace_it_was_on_when_the_order_changes() {
+        let mut app = app(&[GATEWAY, LEDGER]);
+        in_sync(&mut app, GATEWAY);
+        in_sync(&mut app, LEDGER);
+        app.tick();
+        app.move_selection(1);
+        let followed = app.selected_entry().map(|entry| entry.name.clone());
+
+        behind(&mut app, GATEWAY);
+        app.tick();
+
+        asserting!("re-sorting under the user must not move their cursor to another row")
+            .that(&app.selected_entry().map(|entry| entry.name.clone()))
+            .is_equal_to(followed);
+    }
+
+    #[tokio::test]
+    async fn cursor_leaves_a_namespace_the_filter_hides() {
+        let mut app = app(&[GATEWAY, LEDGER]);
+        in_sync(&mut app, GATEWAY);
+        behind(&mut app, LEDGER);
+        app.tick();
+        app.cycle_filter();
+        app.tick();
+
+        assert_that!(app.selected_entry().map(|entry| entry.name.clone()))
+            .is_equal_to(Some(LEDGER.to_string()));
+    }
+
+    #[tokio::test]
+    async fn answer_from_an_earlier_round_is_dropped() {
+        let mut app = app(&[GATEWAY]);
+        let stale = app.listing_round;
+        app.relist_pods();
+        app.accept_pods(
+            stale,
+            GATEWAY,
+            Ok(vec![pod(GATEWAY, "gone-abc12-x1y2z", "4f1c0f2c-8103771")]),
+        );
+
+        asserting!("a slow answer from before R must not put back the pods it saw")
+            .that(&app.selected_entry().map(|entry| entry.pod_list().len()))
+            .is_equal_to(Some(0));
+    }
+
+    #[tokio::test]
+    async fn retrying_a_namespace_kubernetes_refused_asks_it_again() {
+        let mut app = app(&[GATEWAY]);
+        app.accept_pods(app.listing_round, GATEWAY, Err(MsgError::new("forbidden")));
+        app.tick();
+        app.refresh_selected();
+
+        asserting!("the footer offers r for this, so r has to ask Kubernetes and show it")
+            .that(
+                &app.selected_entry()
+                    .map(|entry| matches!(entry.pods, PodsState::Listing)),
+            )
+            .is_equal_to(Some(true));
+    }
+
+    #[tokio::test]
+    async fn nothing_reported_means_nothing_to_dismiss() {
+        let mut app = app(&[GATEWAY]);
+
+        asserting!("Esc would otherwise be swallowed by an invisible message")
+            .that(&app.dismiss_note())
+            .is_false();
+    }
+
+    #[tokio::test]
+    async fn reported_action_is_dismissed_once() {
+        let mut app = app(&[GATEWAY]);
+        app.report(NoteKind::Ok, "opened".to_string());
+        app.dismiss_note();
+
+        assert_that!(app.dismiss_note()).is_false();
+    }
+
+    #[tokio::test]
+    async fn standing_problem_is_marked_as_one() {
+        let mut app = app(&[GATEWAY]);
+        app.accept_pods(app.listing_round, GATEWAY, Err(MsgError::new("forbidden")));
+        app.tick();
+
+        asserting!("the footer must not offer to dismiss what Esc cannot dismiss")
+            .that(&app.note().map(|note| note.standing))
+            .is_equal_to(Some(true));
+    }
+
+    #[tokio::test]
+    async fn namespace_missing_from_the_config_is_not_asked_about() {
+        let mut app = App::new(
+            vec![MAILER.to_string()],
+            repos(&[GATEWAY]),
+            Mode::Commit,
+            Cluster::default(),
+            client(),
+        );
+        app.tick();
+
+        assert_that!(app.reference_label(MAILER)).is_equal_to(MISSING.to_string());
     }
 }

--- a/src/drawer/app.rs
+++ b/src/drawer/app.rs
@@ -1,0 +1,409 @@
+use crate::caller::browser::{commit_url, open_with_hash};
+use crate::git::remote::{
+    commit_status, spawn_lookup, CommitStatus, LookupResult, Mode, RemoteState,
+};
+use crate::k8s::pods::{MyContainer, MyPod};
+use crate::storage::json_storage::JsonStorage;
+use ratatui::widgets::ListState;
+use std::collections::HashMap;
+use std::sync::mpsc::{channel, Receiver, Sender, TryRecvError};
+
+pub const KEY_HINTS: &str = "↑↓ move · ←→/Tab pane · Enter open · m mode · r refresh · q quit";
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Focus {
+    Namespaces,
+    Pods,
+    Containers,
+}
+
+pub struct NamespaceEntry {
+    pub name: String,
+    pub pods: Vec<MyPod>,
+    /// Set when listing pods failed — the namespace stays visible instead of vanishing.
+    pub error: Option<String>,
+}
+
+pub struct App {
+    namespaces: Vec<NamespaceEntry>,
+    repos: JsonStorage,
+    mode: Mode,
+    /// Results are kept per mode, so switching back and forth costs nothing.
+    remotes: HashMap<Mode, HashMap<String, RemoteState>>,
+    tx: Sender<LookupResult>,
+    lookups: Receiver<LookupResult>,
+    focus: Focus,
+    ns_state: ListState,
+    pod_state: ListState,
+    cont_state: ListState,
+    status: String,
+    should_quit: bool,
+}
+
+impl App {
+    pub fn new(namespaces: Vec<NamespaceEntry>, repos: JsonStorage, mode: Mode) -> App {
+        let (tx, lookups) = channel();
+
+        let mut ns_state = ListState::default();
+        if !namespaces.is_empty() {
+            ns_state.select(Some(0));
+        }
+
+        let mut app = App {
+            namespaces,
+            repos,
+            mode,
+            remotes: HashMap::new(),
+            tx,
+            lookups,
+            focus: Focus::Namespaces,
+            ns_state,
+            pod_state: ListState::default(),
+            cont_state: ListState::default(),
+            status: String::new(),
+            should_quit: false,
+        };
+
+        app.reset_pods();
+        app.request_missing();
+
+        app
+    }
+
+    pub fn should_quit(&self) -> bool {
+        self.should_quit
+    }
+
+    pub fn quit(&mut self) {
+        self.should_quit = true;
+    }
+
+    pub fn focus(&self) -> Focus {
+        self.focus
+    }
+
+    /// The last action reported to the user, or the state of the background lookups
+    /// while there is nothing to report.
+    pub fn footer(&self) -> String {
+        if !self.status.is_empty() {
+            return self.status.clone();
+        }
+
+        if let Some(problem) = self.selected_problem() {
+            return problem;
+        }
+
+        let pending = self.current_remotes().map_or(0, |remotes| {
+            remotes
+                .values()
+                .filter(|state| matches!(state, RemoteState::Loading))
+                .count()
+        });
+
+        if pending > 0 {
+            return format!("mode: {} · resolving · {} left", self.mode.label(), pending);
+        }
+
+        let statuses: Vec<CommitStatus> = self
+            .namespaces
+            .iter()
+            .map(|entry| self.namespace_status(entry))
+            .collect();
+
+        let outdated = statuses
+            .iter()
+            .filter(|s| **s == CommitStatus::Outdated)
+            .count();
+        let unresolved = statuses
+            .iter()
+            .filter(|s| **s == CommitStatus::Unknown)
+            .count();
+
+        let mut text = format!(
+            "mode: {} · {} of {} namespaces outdated",
+            self.mode.label(),
+            outdated,
+            statuses.len()
+        );
+        if unresolved > 0 {
+            text.push_str(&format!(" · {} unresolved", unresolved));
+        }
+
+        text
+    }
+
+    pub fn mode(&self) -> Mode {
+        self.mode
+    }
+
+    /// Switching modes reuses whatever was already resolved and only asks for the rest.
+    pub fn toggle_mode(&mut self) {
+        self.mode = self.mode.toggled();
+        self.status.clear();
+        self.request_missing();
+    }
+
+    pub fn namespaces(&self) -> &[NamespaceEntry] {
+        &self.namespaces
+    }
+
+    pub fn ns_state(&mut self) -> &mut ListState {
+        &mut self.ns_state
+    }
+
+    pub fn pod_state(&mut self) -> &mut ListState {
+        &mut self.pod_state
+    }
+
+    pub fn cont_state(&mut self) -> &mut ListState {
+        &mut self.cont_state
+    }
+
+    pub fn selected_namespace(&self) -> Option<&NamespaceEntry> {
+        self.namespaces.get(self.ns_state.selected()?)
+    }
+
+    pub fn selected_pod(&self) -> Option<&MyPod> {
+        self.selected_namespace()?
+            .pods
+            .get(self.pod_state.selected()?)
+    }
+
+    pub fn selected_container(&self) -> Option<&MyContainer> {
+        self.selected_pod()?
+            .containers
+            .get(self.cont_state.selected()?)
+    }
+
+    pub fn remote(&self, namespace: &str) -> Option<&RemoteState> {
+        self.current_remotes()?.get(namespace)
+    }
+
+    pub fn container_status(&self, namespace: &str, container: &MyContainer) -> CommitStatus {
+        commit_status(container.image_ref().as_ref(), self.remote(namespace))
+    }
+
+    pub fn pod_status(&self, namespace: &str, pod: &MyPod) -> CommitStatus {
+        CommitStatus::worst_judged(
+            pod.containers
+                .iter()
+                .map(|container| self.container_status(namespace, container)),
+        )
+    }
+
+    pub fn namespace_status(&self, entry: &NamespaceEntry) -> CommitStatus {
+        if entry.error.is_some() {
+            return CommitStatus::Unknown;
+        }
+
+        CommitStatus::combined(
+            entry
+                .pods
+                .iter()
+                .map(|pod| self.pod_status(&entry.name, pod)),
+        )
+    }
+
+    /// Picks up whatever background lookups have finished since the last call. Results
+    /// are filed under the mode they were requested in, which may no longer be current.
+    pub fn drain_lookups(&mut self) {
+        loop {
+            let (mode, name, state) = match self.lookups.try_recv() {
+                Ok((mode, name, Ok(target))) => (mode, name, RemoteState::Ready(target)),
+                Ok((mode, name, Err(e))) => (mode, name, RemoteState::Failed(e.details)),
+                Err(TryRecvError::Empty) | Err(TryRecvError::Disconnected) => break,
+            };
+
+            self.remotes.entry(mode).or_default().insert(name, state);
+        }
+    }
+
+    pub fn move_selection(&mut self, delta: isize) {
+        let len = self.list_len();
+        if len == 0 {
+            return;
+        }
+
+        let state = match self.focus {
+            Focus::Namespaces => &mut self.ns_state,
+            Focus::Pods => &mut self.pod_state,
+            Focus::Containers => &mut self.cont_state,
+        };
+
+        let current = state.selected().unwrap_or(0) as isize;
+        let next = current.saturating_add(delta).clamp(0, len as isize - 1) as usize;
+        state.select(Some(next));
+
+        match self.focus {
+            Focus::Namespaces => self.reset_pods(),
+            Focus::Pods => self.reset_containers(),
+            Focus::Containers => (),
+        }
+    }
+
+    pub fn focus_next(&mut self) {
+        self.focus = match self.focus {
+            Focus::Namespaces => Focus::Pods,
+            Focus::Pods => Focus::Containers,
+            Focus::Containers => Focus::Containers,
+        };
+    }
+
+    pub fn focus_prev(&mut self) {
+        self.focus = match self.focus {
+            Focus::Namespaces => Focus::Namespaces,
+            Focus::Pods => Focus::Namespaces,
+            Focus::Containers => Focus::Pods,
+        };
+    }
+
+    /// Enter: walks right through the panes, opens the commit on the last one.
+    pub fn activate(&mut self) {
+        match self.focus {
+            Focus::Namespaces | Focus::Pods => self.focus_next(),
+            Focus::Containers => self.open_selected(),
+        }
+    }
+
+    pub fn refresh_selected(&mut self) {
+        let Some(entry) = self.selected_namespace() else {
+            return;
+        };
+        let name = entry.name.clone();
+
+        // a second request would spawn another thread and could land out of order,
+        // overwriting the newer answer with the older one
+        if matches!(self.remote(&name), Some(RemoteState::Loading)) {
+            return;
+        }
+
+        self.request(&name);
+        self.status.clear();
+    }
+
+    /// Why the selected namespace cannot be judged, if that is the case — the reason is
+    /// otherwise recorded but never shown.
+    fn selected_problem(&self) -> Option<String> {
+        let entry = self.selected_namespace()?;
+
+        if let Some(error) = &entry.error {
+            return Some(format!("{}: {}", entry.name, error));
+        }
+
+        match self.remote(&entry.name) {
+            Some(RemoteState::Failed(reason)) => Some(format!("{}: {}", entry.name, reason)),
+            _ => None,
+        }
+    }
+
+    fn open_selected(&mut self) {
+        let Some(entry) = self.selected_namespace() else {
+            return;
+        };
+        let namespace = entry.name.clone();
+
+        let Some(container) = self.selected_container() else {
+            self.status = "No container selected".to_string();
+            return;
+        };
+        let image = container.short_image().to_string();
+
+        let Some(image_ref) = container.image_ref() else {
+            self.status = format!("{}: image carries no tag", image);
+            return;
+        };
+
+        // a release image names a tag, so its commit is only known once tags are fetched
+        let hash = match self.remote(&namespace) {
+            Some(RemoteState::Ready(target)) => target.commit_of(&image_ref),
+            _ => None,
+        };
+
+        let Some(hash) = hash else {
+            self.status = format!(
+                "{}: cannot resolve {} to a commit — try {} mode",
+                image,
+                image_ref.as_str(),
+                self.mode.toggled().label()
+            );
+            return;
+        };
+
+        let Some(repo) = self.repos.get_repo_by_name(&namespace) else {
+            self.status = format!("{} is missing in repos.json", namespace);
+            return;
+        };
+        let url = repo.url.clone();
+
+        self.status = match open_with_hash(&url, &hash) {
+            Ok(_) => format!("Opened {}", commit_url(&url, &hash)),
+            Err(e) => format!("Cannot open browser: {}", e),
+        };
+    }
+
+    /// Asks for every namespace the current mode has no answer for yet.
+    fn request_missing(&mut self) {
+        let pending: Vec<String> = self
+            .namespaces
+            .iter()
+            .map(|entry| entry.name.clone())
+            .filter(|name| self.remote(name).is_none())
+            .collect();
+
+        for name in pending {
+            self.request(&name);
+        }
+    }
+
+    fn request(&mut self, namespace: &str) {
+        let mode = self.mode;
+
+        match self.repos.get_repo_by_name(namespace) {
+            Some(repo) => {
+                let url = repo.url.clone();
+                self.set_remote(namespace, RemoteState::Loading);
+                spawn_lookup(self.tx.clone(), mode, namespace.to_string(), url);
+            }
+            None => {
+                self.set_remote(
+                    namespace,
+                    RemoteState::Failed("missing in repos.json".to_string()),
+                );
+            }
+        }
+    }
+
+    fn current_remotes(&self) -> Option<&HashMap<String, RemoteState>> {
+        self.remotes.get(&self.mode)
+    }
+
+    fn set_remote(&mut self, namespace: &str, state: RemoteState) {
+        self.remotes
+            .entry(self.mode)
+            .or_default()
+            .insert(namespace.to_string(), state);
+    }
+
+    fn list_len(&self) -> usize {
+        match self.focus {
+            Focus::Namespaces => self.namespaces.len(),
+            Focus::Pods => self.selected_namespace().map_or(0, |ns| ns.pods.len()),
+            Focus::Containers => self.selected_pod().map_or(0, |p| p.containers.len()),
+        }
+    }
+
+    fn reset_pods(&mut self) {
+        let has_pods = self
+            .selected_namespace()
+            .is_some_and(|ns| !ns.pods.is_empty());
+        self.pod_state.select(has_pods.then_some(0));
+        self.reset_containers();
+    }
+
+    fn reset_containers(&mut self) {
+        let has_containers = self
+            .selected_pod()
+            .is_some_and(|pod| !pod.containers.is_empty());
+        self.cont_state.select(has_containers.then_some(0));
+    }
+}

--- a/src/drawer/chrome.rs
+++ b/src/drawer/chrome.rs
@@ -1,0 +1,683 @@
+use crate::drawer::app::{App, Filter, Input, NoteKind, Screen};
+use crate::drawer::theme::Theme;
+use crate::git::remote::{Failure, Mode, Unresolved, Verdict};
+use crate::text::ellipsize;
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, Clear, Padding, Paragraph};
+
+/// Below this the interface says so instead of drawing something unreadable.
+pub const MIN_WIDTH: u16 = 60;
+pub const MIN_HEIGHT: u16 = 15;
+/// Below this the panes collapse into a single list.
+pub const WIDE_WIDTH: u16 = 100;
+
+const PROGRESS_WIDTH: usize = 20;
+/// Columns of air kept between any text and the edge it sits against.
+pub const PAD: u16 = 1;
+const SEPARATOR: &str = "│";
+
+/// `giter │ PROD kube-prod │ mode commit tag` and, on the right, the tally and how fresh
+/// the numbers are.
+pub fn header(app: &App, theme: &Theme, width: u16) -> Paragraph<'static> {
+    let width = width.saturating_sub(2 * PAD);
+    let mut left = vec![
+        Span::styled("giter", Style::new().fg(theme.cyan).bold()),
+        Span::styled(format!(" {} ", SEPARATOR), Style::new().fg(theme.faint)),
+    ];
+
+    left.extend(cluster_spans(app, theme));
+    left.push(Span::styled(
+        format!(" {} ", SEPARATOR),
+        Style::new().fg(theme.faint),
+    ));
+    left.push(Span::styled("mode ", Style::new().fg(theme.dim)));
+    left.extend(mode_spans(app.mode(), theme));
+
+    let right = match app.screen() {
+        Screen::Overview => {
+            let mut spans = tally_spans(app, theme);
+            spans.extend(freshness_spans(app, theme));
+            spans
+        }
+        Screen::Detail => {
+            let mut spans = vec![
+                Span::styled("overview ", Style::new().fg(theme.dim)),
+                Span::styled("esc", Style::new().fg(theme.fg2)),
+            ];
+            spans.extend(freshness_spans(app, theme));
+            spans
+        }
+    };
+
+    padded(spread(left, right, width), theme.env_bg)
+}
+
+/// The same information for a terminal too narrow to spell it out.
+pub fn narrow_header(app: &App, theme: &Theme, width: u16) -> Paragraph<'static> {
+    let width = width.saturating_sub(2 * PAD);
+    let left = cluster_spans(app, theme);
+    let right = vec![Span::styled(
+        app.mode().label().to_string(),
+        Style::new().fg(theme.cyan),
+    )];
+
+    padded(spread(left, right, width), theme.env_bg)
+}
+
+/// The bar under the header: the search prompt while typing, the start-up progress while
+/// the cluster answers, and the filter and sort controls the rest of the time.
+pub fn bar(app: &App, theme: &Theme, width: u16) -> Paragraph<'static> {
+    let width = width.saturating_sub(2 * PAD);
+    let line = match (app.input(), app.listing()) {
+        (Input::Search, _) => search_bar(app, theme, width),
+        (_, Some((done, total))) => startup_bar(app, theme, width, done, total),
+        _ => filter_bar(app, theme, width),
+    };
+
+    padded(line, theme.bar)
+}
+
+/// Counts alone, for the narrow layout that has no room for controls.
+pub fn narrow_bar(app: &App, theme: &Theme, width: u16) -> Paragraph<'static> {
+    let width = width.saturating_sub(2 * PAD);
+    let right = match app.listing() {
+        Some((done, total)) => vec![Span::styled(
+            format!("{}/{}", done, total),
+            Style::new().fg(theme.fg2),
+        )],
+        None => vec![Span::styled(app.freshness(), Style::new().fg(theme.dim))],
+    };
+
+    padded(spread(tally_spans(app, theme), right, width), theme.bar)
+}
+
+/// The upper footer line: what just happened, what is being fetched, or the tally.
+pub fn status_line(app: &App, theme: &Theme, width: u16, narrow: bool) -> Paragraph<'static> {
+    let width = width.saturating_sub(2 * PAD);
+    let line = match app.note() {
+        Some(note) => {
+            let (glyph, color) = match note.kind {
+                NoteKind::Ok => ('✓', theme.ok),
+                NoteKind::Warn => ('!', theme.warn),
+                NoteKind::Error => ('✗', theme.bad),
+            };
+            let hint = match (note.retry, note.standing) {
+                (true, true) => "r retry",
+                (true, false) => "r retry · esc dismiss",
+                (false, true) => "",
+                (false, false) => "esc dismiss",
+            };
+
+            spread(
+                vec![
+                    Span::styled(format!("{} ", glyph), Style::new().fg(color)),
+                    Span::styled(
+                        ellipsize(&note.text, (width as usize).saturating_sub(hint.len() + 4)),
+                        Style::new().fg(theme.fg2),
+                    ),
+                ],
+                vec![Span::styled(hint.to_string(), Style::new().fg(theme.faint))],
+                width,
+            )
+        }
+        None => match app.screen() {
+            Screen::Detail => match app.selection_summary() {
+                Some(summary) => spread(
+                    vec![Span::styled(
+                        ellipsize(&summary, (width as usize).saturating_sub(4)),
+                        Style::new().fg(theme.fg2),
+                    )],
+                    match narrow {
+                        true => vec![],
+                        false => vec![Span::styled(
+                            "enter opens the deployed commit in GitLab".to_string(),
+                            Style::new().fg(theme.faint),
+                        )],
+                    },
+                    width,
+                ),
+                None => summary_line(app, theme, width),
+            },
+            // the narrow overview has no NOTE column, so the note of the selected row is
+            // what this line is for
+            Screen::Overview if narrow => match selected_note(app, theme) {
+                Some(line) => line,
+                None => summary_line(app, theme, width),
+            },
+            Screen::Overview => summary_line(app, theme, width),
+        },
+    };
+
+    padded(line, theme.bar)
+}
+
+/// The lower footer line: only keys, and only the ones that do something here.
+pub fn keys_line(app: &App, theme: &Theme, width: u16, narrow: bool) -> Paragraph<'static> {
+    let width = width.saturating_sub(2 * PAD);
+    let keys: Vec<(&str, &str)> = match (app.input(), app.screen(), narrow) {
+        (Input::Search, _, _) => vec![("enter", "keep"), ("esc", "clear"), ("↑↓", "move")],
+        (_, Screen::Overview, true) => vec![
+            ("↑↓", "move"),
+            ("enter", "in"),
+            ("/", "find"),
+            ("?", "keys"),
+            ("q", "quit"),
+        ],
+        (_, Screen::Detail, true) => vec![
+            ("↑↓", "pods"),
+            ("tab", "containers"),
+            ("enter", "commit"),
+            ("esc", "back"),
+            ("?", "keys"),
+        ],
+        (_, Screen::Overview, false) => vec![
+            ("↑↓", "move"),
+            ("enter", "open namespace"),
+            ("/", "search"),
+            ("f", "filter"),
+            ("s", "sort"),
+            ("m", "mode"),
+            ("r", "refresh"),
+            ("?", "help"),
+            ("q", "quit"),
+        ],
+        (_, Screen::Detail, false) => vec![
+            ("↑↓", "pods"),
+            ("←→", "pane"),
+            ("tab", "containers"),
+            ("enter", "open commit"),
+            ("m", "mode"),
+            ("esc", "overview"),
+            ("?", "help"),
+        ],
+    };
+
+    let mut left: Vec<Span> = vec![];
+    for (key, action) in keys {
+        left.push(Span::styled(
+            key.to_string(),
+            Style::new().fg(theme.fg2).bold(),
+        ));
+        left.push(Span::styled(
+            format!(" {}  ", action),
+            Style::new().fg(theme.dim),
+        ));
+    }
+
+    let right = vec![Span::styled(position(app), Style::new().fg(theme.dim))];
+
+    padded(spread(left, right, width), theme.keys_bar)
+}
+
+/// Full key map and the legend of glyphs, over the top of everything else.
+pub fn help(frame: &mut Frame, area: Rect, theme: &Theme) {
+    let keys: [(&str, &str); 13] = [
+        ("↑↓ k j", "move"),
+        ("pgup pgdn", "jump ten rows"),
+        ("home end", "first / last"),
+        ("←→ tab", "switch pane"),
+        ("enter", "open namespace · open commit in GitLab"),
+        ("esc", "back · dismiss · quit"),
+        ("/", "search namespaces"),
+        ("f", "filter: all / problems / unknown"),
+        ("s", "sort: status / name / pods"),
+        ("m", "commit ⇄ tag mode"),
+        ("r", "re-resolve the selected namespace"),
+        ("R", "re-list pods from Kubernetes"),
+        ("q", "quit"),
+    ];
+
+    let legend: [(Verdict, &str); 12] = [
+        (Verdict::InSync, "deployed commit equals the reference"),
+        (
+            Verdict::Behind,
+            "deployed commit differs from the reference",
+        ),
+        (
+            Verdict::Failed(Failure::Kube),
+            "cannot list pods — no access or no such namespace",
+        ),
+        (
+            Verdict::Failed(Failure::Git),
+            "ls-remote failed — the reason is in the row",
+        ),
+        (Verdict::Resolving, "the reference is being fetched"),
+        (
+            Verdict::Unknown(Unresolved::Sidecar),
+            "foreign image — nothing to compare",
+        ),
+        (
+            Verdict::Unknown(Unresolved::Digest),
+            "pinned by digest, the tag carries no commit",
+        ),
+        (
+            Verdict::Unknown(Unresolved::NoConfig),
+            "namespace has no entry in repos.json",
+        ),
+        (
+            Verdict::Unknown(Unresolved::NoTags),
+            "tag mode, but the repository has no tags",
+        ),
+        (
+            Verdict::Unknown(Unresolved::WrongMode),
+            "a release image, and commit mode cannot resolve one",
+        ),
+        (
+            Verdict::Unknown(Unresolved::Finished),
+            "a pod that has run its course — a CronJob leaves those behind",
+        ),
+        (
+            Verdict::Unknown(Unresolved::Empty),
+            "no pods, so nothing to compare",
+        ),
+    ];
+
+    let width = area.width.min(74);
+    let height = area.height.min((keys.len() + legend.len() + 6) as u16);
+    let popup = Rect {
+        x: area.x + (area.width - width) / 2,
+        y: area.y + (area.height - height) / 2,
+        width,
+        height,
+    };
+
+    let mut lines: Vec<Line> = vec![Line::from(vec![
+        Span::styled("Keys", Style::new().fg(theme.cyan).bold()),
+        Span::styled("   esc / ? close", Style::new().fg(theme.faint)),
+    ])];
+
+    for (key, action) in keys {
+        lines.push(Line::from(vec![
+            Span::styled(format!("{:<11}", key), Style::new().fg(theme.cyan)),
+            Span::styled(action.to_string(), Style::new().fg(theme.dim)),
+        ]));
+    }
+
+    lines.push(Line::default());
+    lines.push(Line::from(Span::styled(
+        "Legend",
+        Style::new().fg(theme.cyan).bold(),
+    )));
+
+    for (verdict, meaning) in legend {
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("{}  ", verdict.glyph()),
+                Style::new().fg(theme.verdict(verdict)),
+            ),
+            Span::styled(format!("{:<9}", verdict.code()), Style::new().fg(theme.fg2)),
+            Span::styled(meaning.to_string(), Style::new().fg(theme.dim)),
+        ]));
+    }
+
+    frame.render_widget(Clear, popup);
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(
+                Block::new()
+                    .borders(Borders::ALL)
+                    .border_style(Style::new().fg(theme.cyan))
+                    .padding(Padding::horizontal(1)),
+            )
+            .style(Style::new().bg(theme.bar)),
+        popup,
+    );
+}
+
+pub fn too_small(frame: &mut Frame, area: Rect, theme: &Theme) {
+    let text = format!(
+        "terminal too small: {}×{}, need {}×{}",
+        area.width, area.height, MIN_WIDTH, MIN_HEIGHT
+    );
+
+    frame.render_widget(
+        Paragraph::new(ellipsize(&text, area.width as usize))
+            .style(Style::new().fg(theme.warn).bg(theme.bg)),
+        area,
+    );
+}
+
+/// A one-line bar: the background reaches the edges of the screen, the text does not.
+fn padded(line: Line<'static>, background: Color) -> Paragraph<'static> {
+    Paragraph::new(line)
+        .block(Block::new().padding(Padding::horizontal(PAD)))
+        .style(Style::new().bg(background))
+}
+
+/// Left-aligned and right-aligned spans on one line, whatever the width.
+pub fn spread(left: Vec<Span<'static>>, right: Vec<Span<'static>>, width: u16) -> Line<'static> {
+    let used: usize = left.iter().chain(right.iter()).map(Span::width).sum();
+    let gap = (width as usize).saturating_sub(used).max(1);
+
+    let mut spans = left;
+    spans.push(Span::raw(" ".repeat(gap)));
+    spans.extend(right);
+
+    Line::from(spans)
+}
+
+pub fn glyph(verdict: Verdict, theme: &Theme, spinner: char) -> Span<'static> {
+    let symbol = match verdict {
+        Verdict::Resolving => spinner,
+        other => other.glyph(),
+    };
+
+    let style = Style::new().fg(theme.verdict(verdict));
+
+    Span::styled(
+        format!("{} ", symbol),
+        match verdict {
+            Verdict::Behind => style.bold(),
+            _ => style,
+        },
+    )
+}
+
+/// How fresh the numbers are — or, before anything has come back, that the tool is starting.
+fn freshness_spans(app: &App, theme: &Theme) -> Vec<Span<'static>> {
+    let freshness = app.freshness();
+    let text = match freshness.is_empty() {
+        true => "starting up".to_string(),
+        false => freshness,
+    };
+
+    vec![
+        Span::styled(format!(" {} ", SEPARATOR), Style::new().fg(theme.faint)),
+        Span::styled(text, Style::new().fg(theme.dim)),
+    ]
+}
+
+fn cluster_spans(app: &App, theme: &Theme) -> Vec<Span<'static>> {
+    let mut spans = vec![];
+
+    if let Some(env) = app.cluster.env {
+        spans.push(Span::styled(
+            format!(" {} ", env.label()),
+            Style::new().fg(theme.env_fg).bg(theme.env).bold(),
+        ));
+        spans.push(Span::raw(" "));
+    }
+
+    spans.push(Span::styled(
+        app.cluster
+            .context
+            .clone()
+            .unwrap_or_else(|| "no kubeconfig context".to_string()),
+        Style::new().fg(theme.env),
+    ));
+
+    spans
+}
+
+fn mode_spans(mode: Mode, theme: &Theme) -> Vec<Span<'static>> {
+    [Mode::Commit, Mode::Tag]
+        .into_iter()
+        .map(|candidate| {
+            let label = format!(" {} ", candidate.label());
+
+            match candidate == mode {
+                true => Span::styled(label, Style::new().fg(theme.bg).bg(theme.cyan).bold()),
+                false => Span::styled(label, Style::new().fg(theme.faint)),
+            }
+        })
+        .collect()
+}
+
+fn tally_spans(app: &App, theme: &Theme) -> Vec<Span<'static>> {
+    let counts = app.counts();
+
+    vec![
+        Span::styled(format!("● {}  ", counts.in_sync), Style::new().fg(theme.ok)),
+        Span::styled(
+            format!("▼ {}  ", counts.behind),
+            Style::new().fg(theme.bad).bold(),
+        ),
+        Span::styled(
+            format!("✗ {}  ", counts.failed),
+            Style::new().fg(theme.warn),
+        ),
+        Span::styled(format!("○ {}", counts.unknown), Style::new().fg(theme.dim)),
+    ]
+}
+
+/// What the overview would have said in its NOTE column about the row under the cursor.
+fn selected_note(app: &App, theme: &Theme) -> Option<Line<'static>> {
+    let row = app.selected_row()?;
+    if row.note.is_empty() {
+        return None;
+    }
+
+    Some(Line::from(vec![
+        glyph(row.verdict, theme, app.spinner()),
+        Span::styled(row.note, Style::new().fg(theme.fg2)),
+    ]))
+}
+
+fn summary_line(app: &App, theme: &Theme, width: u16) -> Line<'static> {
+    let counts = app.counts();
+    let resolving = app.resolving();
+
+    if resolving > 0 {
+        return spread(
+            vec![
+                Span::styled(format!("{} ", app.spinner()), Style::new().fg(theme.cyan)),
+                Span::styled(
+                    "resolving references ".to_string(),
+                    Style::new().fg(theme.fg2),
+                ),
+            ]
+            .into_iter()
+            .chain(progress_spans(
+                app.total_namespaces() - resolving,
+                app.total_namespaces(),
+                theme,
+            ))
+            .chain([Span::styled(
+                format!(
+                    " {} of {}",
+                    app.total_namespaces() - resolving,
+                    app.total_namespaces()
+                ),
+                Style::new().fg(theme.fg2),
+            )])
+            .collect(),
+            vec![Span::styled(
+                "background · the interface stays responsive".to_string(),
+                Style::new().fg(theme.dim),
+            )],
+            width,
+        );
+    }
+
+    spread(
+        vec![
+            Span::styled(
+                format!("● {} in sync", counts.in_sync),
+                Style::new().fg(theme.ok),
+            ),
+            Span::styled(" · ".to_string(), Style::new().fg(theme.faint)),
+            Span::styled(
+                format!("▼ {} behind", counts.behind),
+                Style::new().fg(theme.bad),
+            ),
+            Span::styled(" · ".to_string(), Style::new().fg(theme.faint)),
+            Span::styled(
+                format!("✗ {} failed", counts.failed),
+                Style::new().fg(theme.warn),
+            ),
+            Span::styled(" · ".to_string(), Style::new().fg(theme.faint)),
+            Span::styled(
+                format!("○ {} unknown", counts.unknown),
+                Style::new().fg(theme.dim),
+            ),
+        ],
+        vec![Span::styled(
+            format!("idle · {}", app.freshness()),
+            Style::new().fg(theme.dim),
+        )],
+        width,
+    )
+}
+
+fn search_bar(app: &App, theme: &Theme, width: u16) -> Line<'static> {
+    spread(
+        vec![
+            Span::styled("/ ".to_string(), Style::new().fg(theme.cyan).bold()),
+            Span::styled(app.query().to_string(), Style::new().fg(theme.fg)),
+            Span::styled("▏".to_string(), Style::new().fg(theme.cyan)),
+        ],
+        vec![Span::styled(
+            format!(
+                "{} of {}",
+                app.matching_namespaces(),
+                app.total_namespaces()
+            ),
+            Style::new().fg(theme.dim),
+        )],
+        width,
+    )
+}
+
+fn startup_bar(app: &App, theme: &Theme, width: u16, done: usize, total: usize) -> Line<'static> {
+    let mut left = vec![
+        Span::styled(format!("{} ", app.spinner()), Style::new().fg(theme.cyan)),
+        Span::styled("listing pods ".to_string(), Style::new().fg(theme.fg2)),
+    ];
+    left.extend(progress_spans(done, total, theme));
+    left.push(Span::styled(
+        format!(" {}/{}", done, total),
+        Style::new().fg(theme.fg2),
+    ));
+
+    spread(
+        left,
+        vec![Span::styled(
+            format!("resolving git references · {} left", app.resolving()),
+            Style::new().fg(theme.dim),
+        )],
+        width,
+    )
+}
+
+fn filter_bar(app: &App, theme: &Theme, width: u16) -> Line<'static> {
+    let counts = app.counts();
+    let chips = [
+        (Filter::All, app.total_namespaces()),
+        (Filter::Problems, counts.behind + counts.failed),
+        (Filter::Unknown, counts.unknown),
+    ];
+
+    let mut left = vec![Span::styled(
+        "filter ".to_string(),
+        Style::new().fg(theme.dim),
+    )];
+
+    for (filter, count) in chips {
+        let label = format!(" {} {} ", filter.label(), count);
+
+        left.push(match filter == app.filter() {
+            true => Span::styled(label, Style::new().fg(theme.fg).bg(theme.selection)),
+            false => Span::styled(label, Style::new().fg(theme.dim)),
+        });
+    }
+
+    left.push(Span::styled(
+        " f ".to_string(),
+        Style::new().fg(theme.faint),
+    ));
+    left.push(Span::styled(
+        format!("{}  ", SEPARATOR),
+        Style::new().fg(theme.faint),
+    ));
+    left.push(Span::styled(
+        "sort ".to_string(),
+        Style::new().fg(theme.dim),
+    ));
+    left.push(Span::styled(
+        format!("{} ▾", app.sort().label()),
+        Style::new().fg(theme.fg2),
+    ));
+
+    spread(
+        left,
+        vec![Span::styled(
+            format!(
+                "{} namespaces · {} pods · {} containers",
+                app.total_namespaces(),
+                app.total_pods(),
+                app.total_containers()
+            ),
+            Style::new().fg(theme.dim),
+        )],
+        width,
+    )
+}
+
+fn progress_spans(done: usize, total: usize, theme: &Theme) -> Vec<Span<'static>> {
+    let filled = match total {
+        0 => PROGRESS_WIDTH,
+        total => done * PROGRESS_WIDTH / total,
+    };
+
+    vec![
+        Span::styled("█".repeat(filled), Style::new().fg(theme.ok)),
+        Span::styled(
+            "█".repeat(PROGRESS_WIDTH - filled),
+            Style::new().fg(theme.line),
+        ),
+    ]
+}
+
+fn position(app: &App) -> String {
+    let (label, index, total) = match app.screen() {
+        Screen::Overview => ("", app.ns_position(), app.matching_namespaces()),
+        Screen::Detail => ("pod ", app.pod_position(), app.pod_rows().len()),
+    };
+
+    match (index, total) {
+        (_, 0) => "0/0".to_string(),
+        (Some(index), total) => format!("{}{}/{}", label, index + 1, total),
+        (None, total) => format!("{}-/{}", label, total),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use speculoos::prelude::*;
+
+    fn text(content: &str) -> Vec<Span<'static>> {
+        vec![Span::raw(content.to_string())]
+    }
+
+    #[test]
+    fn a_line_of_two_halves_fills_the_width_it_is_given() {
+        let width = 40;
+        let line = spread(text("● 13 in sync"), text("idle"), width);
+
+        assert_that!(line.width()).is_equal_to(width as usize);
+    }
+
+    #[test]
+    fn halves_that_do_not_fit_are_still_kept_apart() {
+        let line = spread(text("cannot list pods: forbidden"), text("r retry"), 20);
+
+        asserting!("running the two together would read as one sentence")
+            .that(&line.spans.iter().any(|span| span.content.trim().is_empty()))
+            .is_true();
+    }
+
+    #[test]
+    fn progress_of_nothing_does_not_divide_by_zero() {
+        let bar = progress_spans(0, 0, &Theme::new(None, false));
+
+        assert_that!(bar.iter().map(Span::width).sum::<usize>()).is_equal_to(PROGRESS_WIDTH);
+    }
+
+    #[test]
+    fn progress_bar_keeps_its_width_as_it_fills() {
+        let bar = progress_spans(7, 19, &Theme::new(None, false));
+
+        assert_that!(bar.iter().map(Span::width).sum::<usize>()).is_equal_to(PROGRESS_WIDTH);
+    }
+}

--- a/src/drawer/detail.rs
+++ b/src/drawer/detail.rs
@@ -1,0 +1,431 @@
+use crate::drawer::app::{App, ContainerRow, MiniRow, Pane, PodRow, RefKind};
+use crate::drawer::chrome::{glyph, spread, PAD};
+use crate::drawer::overview::{matched_spans, name_color, name_spans, scrollbar, split_name};
+use crate::drawer::theme::Theme;
+use crate::git::remote::Verdict;
+use crate::k8s::pods::is_calm;
+use crate::text::{ellipsize, fit_head, split_pod_name};
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, Cell, HighlightSpacing, Paragraph, Row, Table};
+
+const MINI_WIDTH: u16 = 38;
+const MINI_PODS: u16 = 3;
+/// One column of the cursor, plus the single space `Table` keeps between columns.
+const CURSOR: u16 = 1;
+const GAP: u16 = 1;
+/// What the mini list leaves for a name: its width less the border, the padding either
+/// side, the scrollbar, the cursor, the glyph, the pod count and the gaps between them.
+const MINI_NAME: u16 = MINI_WIDTH - 1 - 2 * PAD - SCROLLBAR - CURSOR - GLYPH - MINI_PODS - 2 * GAP;
+/// The bar itself plus a column of air, so the pod counts do not run into it.
+const SCROLLBAR: u16 = 1 + GAP;
+const SUMMARY_HEIGHT: u16 = 4;
+const GLYPH: u16 = 2;
+const COMMIT: u16 = 11;
+const STATUS: u16 = 18;
+const RESTARTS: u16 = 4;
+const AGE: u16 = 5;
+const CONTAINERS: u16 = 5;
+const CONTAINER_ROWS: usize = 4;
+const CONTAINER_NAME: u16 = 30;
+const CONTAINER_TAG: u16 = 22;
+
+/// One namespace taken apart: its pods, and the containers of the selected pod.
+pub fn draw(frame: &mut Frame, area: Rect, app: &mut App, theme: &Theme, wide: bool) {
+    let work = match wide {
+        true => {
+            let [mini, work] =
+                Layout::horizontal([Constraint::Length(MINI_WIDTH), Constraint::Fill(1)])
+                    .areas(area);
+            draw_namespaces(frame, mini, app, theme);
+            work
+        }
+        false => area,
+    };
+    let work = work.inner(Margin::new(PAD, 0));
+
+    let containers = app.container_rows();
+    let height = 2 + containers.len().clamp(1, CONTAINER_ROWS) as u16;
+
+    let [summary, pods, list] = Layout::vertical([
+        Constraint::Length(SUMMARY_HEIGHT),
+        Constraint::Fill(1),
+        Constraint::Length(height),
+    ])
+    .areas(work);
+
+    draw_summary(frame, summary, app, theme);
+    draw_pods(frame, pods, app, theme, wide);
+    draw_containers(frame, list, app, theme, containers);
+}
+
+/// The narrow list of namespaces, grouped by family so that the eye can jump between
+/// products rather than scanning one long alphabet.
+fn draw_namespaces(frame: &mut Frame, area: Rect, app: &mut App, theme: &Theme) {
+    let focused = app.pane() == Pane::Namespaces;
+    let rows = app.mini_rows();
+    let selected = app.mini_selected();
+    let query = app.query().to_string();
+    let spinner = app.spinner();
+    let position = format!(
+        "{}/{}",
+        app.ns_position().map(|i| i + 1).unwrap_or(0),
+        app.matching_namespaces()
+    );
+
+    let block = Block::new()
+        .borders(Borders::RIGHT)
+        .border_style(Style::new().fg(match focused {
+            true => theme.cyan,
+            false => theme.line,
+        }));
+    let inner = block.inner(area).inner(Margin::new(PAD, 0));
+    frame.render_widget(block, area);
+
+    let [head, rest] = Layout::vertical([Constraint::Length(1), Constraint::Fill(1)]).areas(inner);
+    let [body, _, scroll] = Layout::horizontal([
+        Constraint::Fill(1),
+        Constraint::Length(GAP),
+        Constraint::Length(1),
+    ])
+    .areas(rest);
+
+    frame.render_widget(
+        Paragraph::new(spread(
+            vec![Span::styled(
+                "NAMESPACES".to_string(),
+                Style::new().fg(pane_title(focused, theme)),
+            )],
+            vec![Span::styled(position, Style::new().fg(theme.faint))],
+            head.width,
+        )),
+        head,
+    );
+
+    let widths = [
+        Constraint::Length(GLYPH),
+        Constraint::Fill(1),
+        Constraint::Length(MINI_PODS),
+    ];
+
+    let body_rows: Vec<Row> = rows
+        .iter()
+        .map(|row| match row {
+            MiniRow::Family(family) => Row::new(vec![
+                Cell::from(""),
+                Cell::from(family_heading(family)).style(Style::new().fg(theme.faint)),
+                Cell::from(""),
+            ]),
+            MiniRow::Namespace(ns) => Row::new(vec![
+                Cell::from(Line::from(glyph(ns.verdict, theme, spinner))),
+                Cell::from(Line::from(matched_spans(
+                    &ellipsize(split_name(ns).1, MINI_NAME as usize),
+                    &query,
+                    theme,
+                    name_color(ns, theme),
+                ))),
+                Cell::from(
+                    Text::from(match ns.pods {
+                        Some(count) => count.to_string(),
+                        None => "—".to_string(),
+                    })
+                    .right_aligned(),
+                )
+                .style(Style::new().fg(theme.faint)),
+            ]),
+        })
+        .collect();
+
+    let table = Table::new(body_rows, widths)
+        .row_highlight_style(Style::new().bg(selection(focused, theme)))
+        .highlight_symbol(Span::styled("▌", Style::new().fg(theme.cyan)))
+        .highlight_spacing(HighlightSpacing::Always);
+
+    let state = app.ns_state();
+    state.select(selected);
+    frame.render_stateful_widget(table, body, state);
+
+    scrollbar(frame, scroll, theme, rows.len(), app.ns_state().offset());
+}
+
+/// The heading spells out the prefix its rows leave out, and a rule fills the rest of the
+/// column.
+fn family_heading(family: &str) -> String {
+    let rule = (MINI_NAME as usize).saturating_sub(family.chars().count() + 1);
+
+    format!("{} {}", family, "─".repeat(rule))
+}
+
+/// What the namespace is, where its code lives, and what its pods are measured against.
+fn draw_summary(frame: &mut Frame, area: Rect, app: &App, theme: &Theme) {
+    let Some(row) = app.selected_row() else {
+        return;
+    };
+    let (reference, explanation) = app.reference_detail();
+
+    let block = Block::new()
+        .borders(Borders::BOTTOM)
+        .border_style(Style::new().fg(theme.line));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let mut title = vec![glyph(row.verdict, theme, app.spinner())];
+    title.extend(name_spans(&row, "", theme, (inner.width / 2) as usize));
+
+    let room = |taken: usize| (inner.width as usize).saturating_sub(taken + 4);
+    let hint = "r to re-resolve";
+
+    let lines = vec![
+        spread(
+            title,
+            vec![Span::styled(
+                ellipsize(&row.note, room(row.name.chars().count() + GLYPH as usize)),
+                Style::new().fg(theme.verdict(row.verdict)),
+            )],
+            inner.width,
+        ),
+        Line::from(vec![
+            Span::styled("repo      ".to_string(), Style::new().fg(theme.dim)),
+            Span::styled(
+                app.repo_url(&row.name)
+                    .unwrap_or("missing in repos.json")
+                    .to_string(),
+                Style::new().fg(theme.fg2),
+            ),
+        ]),
+        spread(
+            vec![
+                Span::styled("reference ".to_string(), Style::new().fg(theme.dim)),
+                Span::styled(reference.clone(), Style::new().fg(theme.fg)),
+                Span::styled(
+                    format!(
+                        "  {}",
+                        ellipsize(
+                            &explanation,
+                            room(10 + reference.chars().count() + hint.len())
+                        )
+                    ),
+                    Style::new().fg(theme.dim),
+                ),
+            ],
+            vec![Span::styled(hint.to_string(), Style::new().fg(theme.faint))],
+            inner.width,
+        ),
+    ];
+
+    frame.render_widget(Paragraph::new(lines), inner);
+}
+
+fn draw_pods(frame: &mut Frame, area: Rect, app: &mut App, theme: &Theme, wide: bool) {
+    let focused = app.pane() == Pane::Pods;
+    let rows = app.pod_rows();
+    let selected = app.pod_position();
+    let spinner = app.spinner();
+
+    let reference_title = match app.selected_kind() {
+        RefKind::Commits => "COMMIT",
+        RefKind::Tags => "TAG",
+        RefKind::Mixed => "DEPLOYED",
+    };
+
+    let name_width = match wide {
+        true => area.width.saturating_sub(
+            GLYPH + COMMIT + STATUS + RESTARTS + AGE + CONTAINERS + 6 * GAP + CURSOR + SCROLLBAR,
+        ),
+        false => area
+            .width
+            .saturating_sub(GLYPH + COMMIT + CONTAINERS + 3 * GAP + CURSOR + SCROLLBAR),
+    } as usize;
+
+    let (widths, header) = match wide {
+        true => (
+            vec![
+                Constraint::Length(GLYPH),
+                Constraint::Fill(1),
+                Constraint::Length(COMMIT),
+                Constraint::Length(STATUS),
+                Constraint::Length(RESTARTS),
+                Constraint::Length(AGE),
+                Constraint::Length(CONTAINERS),
+            ],
+            vec![
+                Cell::from(""),
+                Cell::from("POD"),
+                Cell::from(reference_title),
+                Cell::from("STATUS"),
+                Cell::from(Text::from("RST").right_aligned()),
+                Cell::from(Text::from("AGE").right_aligned()),
+                Cell::from(Text::from("CTR").right_aligned()),
+            ],
+        ),
+        false => (
+            vec![
+                Constraint::Length(GLYPH),
+                Constraint::Fill(1),
+                Constraint::Length(COMMIT),
+                Constraint::Length(CONTAINERS),
+            ],
+            vec![
+                Cell::from(""),
+                Cell::from("POD"),
+                Cell::from(reference_title),
+                Cell::from(Text::from("CTR").right_aligned()),
+            ],
+        ),
+    };
+
+    let body: Vec<Row> = rows
+        .iter()
+        .map(|pod| {
+            let name = Cell::from(Line::from(pod_name_spans(pod, theme, name_width)));
+            let reference = Cell::from(ellipsize(&pod.reference, COMMIT as usize - 1))
+                .style(Style::new().fg(theme.verdict(pod.verdict)));
+            let containers = Cell::from(Text::from(pod.readiness.clone()).right_aligned())
+                .style(Style::new().fg(theme.dim));
+
+            let cells = match wide {
+                true => vec![
+                    Cell::from(Line::from(glyph(pod.verdict, theme, spinner))),
+                    name,
+                    reference,
+                    Cell::from(ellipsize(&pod.status, STATUS as usize - 1)).style(Style::new().fg(
+                        match is_calm(&pod.status) {
+                            true => theme.dim,
+                            false => theme.bad,
+                        },
+                    )),
+                    Cell::from(Text::from(pod.restarts.to_string()).right_aligned()).style(
+                        Style::new().fg(match pod.restarts {
+                            0 => theme.faint,
+                            _ => theme.warn,
+                        }),
+                    ),
+                    Cell::from(Text::from(pod.age.clone()).right_aligned())
+                        .style(Style::new().fg(theme.dim)),
+                    containers,
+                ],
+                false => vec![
+                    Cell::from(Line::from(glyph(pod.verdict, theme, spinner))),
+                    name,
+                    reference,
+                    containers,
+                ],
+            };
+
+            Row::new(cells)
+        })
+        .collect();
+
+    let table = Table::new(body, widths)
+        .header(Row::new(header).style(Style::new().fg(pane_title(focused, theme))))
+        .row_highlight_style(Style::new().bg(selection(focused, theme)))
+        .highlight_symbol(Span::styled("▌", Style::new().fg(theme.cyan)))
+        .highlight_spacing(HighlightSpacing::Always);
+
+    let [table_area, _, scroll] = Layout::horizontal([
+        Constraint::Fill(1),
+        Constraint::Length(GAP),
+        Constraint::Length(1),
+    ])
+    .areas(area);
+
+    let state = app.pod_state();
+    state.select(selected);
+    frame.render_stateful_widget(table, table_area, state);
+
+    scrollbar(frame, scroll, theme, rows.len(), app.pod_state().offset());
+}
+
+/// Containers of the selected pod, each one saying in words why it is judged the way it is.
+fn draw_containers(
+    frame: &mut Frame,
+    area: Rect,
+    app: &mut App,
+    theme: &Theme,
+    rows: Vec<ContainerRow>,
+) {
+    let focused = app.pane() == Pane::Containers;
+    let selected = app.container_position();
+    let spinner = app.spinner();
+    let title = match (app.selected_entry(), app.selected_pod()) {
+        (Some(entry), Some(pod)) => {
+            let parts = split_pod_name(&pod.name, &entry.name);
+            format!("CONTAINERS OF …{}{}", parts.replicaset, parts.suffix)
+        }
+        _ => "CONTAINERS".to_string(),
+    };
+
+    let block = Block::new()
+        .borders(Borders::TOP)
+        .border_style(Style::new().fg(theme.line))
+        .title(Span::styled(
+            title,
+            Style::new().fg(pane_title(focused, theme)),
+        ));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let widths = [
+        Constraint::Length(GLYPH),
+        Constraint::Length(CONTAINER_NAME),
+        Constraint::Length(CONTAINER_TAG),
+        Constraint::Fill(1),
+    ];
+
+    let body: Vec<Row> = rows
+        .iter()
+        .map(|container| {
+            Row::new(vec![
+                Cell::from(Line::from(glyph(container.verdict, theme, spinner))),
+                Cell::from(ellipsize(&container.name, CONTAINER_NAME as usize - 1)).style(
+                    Style::new().fg(match container.verdict {
+                        Verdict::InSync => theme.fg2,
+                        _ => theme.fg,
+                    }),
+                ),
+                Cell::from(ellipsize(&container.tag, CONTAINER_TAG as usize - 1))
+                    .style(Style::new().fg(theme.verdict(container.verdict))),
+                Cell::from(container.why.clone()).style(Style::new().fg(theme.dim)),
+            ])
+        })
+        .collect();
+
+    let table = Table::new(body, widths)
+        .row_highlight_style(Style::new().bg(selection(focused, theme)))
+        .highlight_symbol(Span::styled("▌", Style::new().fg(theme.cyan)))
+        .highlight_spacing(HighlightSpacing::Always);
+
+    let state = app.cont_state();
+    state.select(selected);
+    frame.render_stateful_widget(table, inner, state);
+}
+
+/// Three levels of brightness: the workload prefix, the ReplicaSet hash that tells an old
+/// rollout from a new one, and the suffix. The prefix is the first to be cut.
+fn pod_name_spans(pod: &PodRow, theme: &Theme, width: usize) -> Vec<Span<'static>> {
+    let telling = format!("{}{}", pod.replicaset, pod.suffix);
+    let (prefix, kept) = fit_head(&pod.prefix, &telling, width);
+
+    if kept != telling {
+        return vec![Span::styled(kept, Style::new().fg(theme.fg))];
+    }
+
+    vec![
+        Span::styled(prefix, Style::new().fg(theme.faint)),
+        Span::styled(pod.replicaset.clone(), Style::new().fg(theme.dim)),
+        Span::styled(pod.suffix.clone(), Style::new().fg(theme.fg)),
+    ]
+}
+
+fn pane_title(focused: bool, theme: &Theme) -> Color {
+    match focused {
+        true => theme.cyan,
+        false => theme.dim,
+    }
+}
+
+fn selection(focused: bool, theme: &Theme) -> Color {
+    match focused {
+        true => theme.selection,
+        false => theme.bar,
+    }
+}

--- a/src/drawer/mod.rs
+++ b/src/drawer/mod.rs
@@ -1,1 +1,2 @@
+pub mod app;
 pub mod terminal;

--- a/src/drawer/mod.rs
+++ b/src/drawer/mod.rs
@@ -1,2 +1,6 @@
 pub mod app;
+pub mod chrome;
+pub mod detail;
+pub mod overview;
 pub mod terminal;
+pub mod theme;

--- a/src/drawer/overview.rs
+++ b/src/drawer/overview.rs
@@ -1,0 +1,418 @@
+use crate::drawer::app::{App, Deployed, NsRow, RefKind};
+use crate::drawer::chrome::{glyph, PAD};
+use crate::drawer::theme::Theme;
+use crate::git::remote::Verdict;
+use crate::text::{ellipsize, fit_head};
+use ratatui::prelude::*;
+use ratatui::widgets::{
+    Cell, HighlightSpacing, Row, Scrollbar, ScrollbarOrientation, ScrollbarState, Table,
+};
+
+const GLYPH: u16 = 2;
+const PODS: u16 = 5;
+const DEPLOYED: u16 = 30;
+const REFERENCE: u16 = 12;
+const GROUP_WIDTH: usize = 15;
+/// Room for `+12` once a namespace runs more commits than the column can list.
+const HIDDEN_WIDTH: usize = 4;
+const NARROW_REFERENCE: u16 = 11;
+/// One column of the cursor, plus the single space `Table` keeps between columns.
+const CURSOR: u16 = 1;
+const GAP: u16 = 1;
+
+/// The whole cluster in one table, worst namespaces first.
+pub fn draw(frame: &mut Frame, area: Rect, app: &mut App, theme: &Theme) {
+    let area = area.inner(Margin::new(PAD, 0));
+    let title = deployed_title(app.deployed_kind());
+    let rows = app.overview_rows();
+    let selected = app.ns_position();
+    let query = app.query().to_string();
+    let spinner = app.spinner();
+
+    let [table_area, _, scroll_area] = Layout::horizontal([
+        Constraint::Fill(1),
+        Constraint::Length(GAP),
+        Constraint::Length(1),
+    ])
+    .areas(area);
+
+    let (name_width, note_width) = flexible(table_area.width);
+    let widths = columns(name_width);
+
+    let header = Row::new(vec![
+        Cell::from(""),
+        Cell::from("NAMESPACE"),
+        Cell::from(Text::from("PODS").right_aligned()),
+        Cell::from(title),
+        Cell::from("REFERENCE"),
+        Cell::from("NOTE"),
+    ])
+    .style(Style::new().fg(theme.dim));
+
+    let body: Vec<Row> = rows
+        .iter()
+        .map(|row| {
+            Row::new(vec![
+                Cell::from(Line::from(glyph(row.verdict, theme, spinner))),
+                Cell::from(Line::from(name_spans(row, &query, theme, name_width))),
+                Cell::from(
+                    Text::from(match row.pods {
+                        Some(count) => count.to_string(),
+                        None => "—".to_string(),
+                    })
+                    .right_aligned(),
+                )
+                .style(Style::new().fg(theme.dim)),
+                Cell::from(Line::from(deployed_spans(row, theme))),
+                Cell::from(row.reference.clone())
+                    .style(Style::new().fg(reference_color(row, theme))),
+                Cell::from(ellipsize(&row.note, note_width))
+                    .style(Style::new().fg(note_color(row.verdict, theme))),
+            ])
+        })
+        .collect();
+
+    let table = Table::new(body, widths)
+        .header(header)
+        .row_highlight_style(Style::new().bg(theme.selection))
+        .highlight_symbol(Span::styled("▌", Style::new().fg(theme.cyan)))
+        .highlight_spacing(HighlightSpacing::Always);
+
+    let state = app.ns_state();
+    state.select(selected);
+    frame.render_stateful_widget(table, table_area, state);
+
+    scrollbar(
+        frame,
+        scroll_area,
+        theme,
+        rows.len(),
+        app.ns_state().offset(),
+    );
+}
+
+/// Under a hundred columns the table gives up everything but the verdict, the name, the
+/// deployed reference and the pod count.
+pub fn draw_narrow(frame: &mut Frame, area: Rect, app: &mut App, theme: &Theme) {
+    let area = area.inner(Margin::new(PAD, 0));
+    let rows = app.overview_rows();
+    let selected = app.ns_position();
+    let query = app.query().to_string();
+    let spinner = app.spinner();
+
+    let widths = [
+        Constraint::Length(GLYPH),
+        Constraint::Fill(1),
+        Constraint::Length(NARROW_REFERENCE),
+        Constraint::Length(PODS),
+    ];
+
+    let body: Vec<Row> = rows
+        .iter()
+        .map(|row| {
+            let deployed = row.deployed.first();
+
+            Row::new(vec![
+                Cell::from(Line::from(glyph(row.verdict, theme, spinner))),
+                Cell::from(Line::from(name_spans(
+                    row,
+                    &query,
+                    theme,
+                    narrow_name_width(area.width),
+                ))),
+                Cell::from(
+                    deployed
+                        .map(|group| group.label.clone())
+                        .unwrap_or_else(|| "—".to_string()),
+                )
+                .style(Style::new().fg(match deployed {
+                    Some(group) => theme.verdict(group.verdict),
+                    None => theme.dim,
+                })),
+                Cell::from(
+                    Text::from(match row.pods {
+                        Some(count) => count.to_string(),
+                        None => "—".to_string(),
+                    })
+                    .right_aligned(),
+                )
+                .style(Style::new().fg(theme.dim)),
+            ])
+        })
+        .collect();
+
+    let table = Table::new(body, widths)
+        .row_highlight_style(Style::new().bg(theme.selection))
+        .highlight_symbol(Span::styled("▌", Style::new().fg(theme.cyan)))
+        .highlight_spacing(HighlightSpacing::Always);
+
+    let state = app.ns_state();
+    state.select(selected);
+    frame.render_stateful_widget(table, area, state);
+}
+
+/// The shared prefix is dimmed, and when the column runs out it is the prefix that gives
+/// up room — the tail is what tells one namespace from another. What the search matched is
+/// underlined on top of that.
+pub fn name_spans(row: &NsRow, query: &str, theme: &Theme, width: usize) -> Vec<Span<'static>> {
+    let (prefix, tail) = split_name(row);
+    let (prefix, tail) = fit_head(prefix, tail, width);
+
+    let mut spans = vec![Span::styled(prefix, Style::new().fg(theme.faint))];
+    spans.extend(matched_spans(&tail, query, theme, name_color(row, theme)));
+
+    spans
+}
+
+/// Where a namespace name stops repeating its family and starts telling them apart.
+pub fn split_name(row: &NsRow) -> (&str, &str) {
+    let cut = row
+        .name
+        .char_indices()
+        .nth(row.prefix)
+        .map(|(index, _)| index)
+        .unwrap_or(row.name.len());
+
+    row.name.split_at(cut)
+}
+
+pub fn name_color(row: &NsRow, theme: &Theme) -> Color {
+    match row.verdict {
+        Verdict::InSync => theme.fg2,
+        _ => theme.fg,
+    }
+}
+
+/// Draws `text`, underlining the part the search matched.
+pub fn matched_spans(text: &str, query: &str, theme: &Theme, color: Color) -> Vec<Span<'static>> {
+    let Some(at) = hit(text, query) else {
+        return vec![Span::styled(text.to_string(), Style::new().fg(color))];
+    };
+
+    vec![
+        Span::styled(text[..at].to_string(), Style::new().fg(color)),
+        Span::styled(
+            text[at..at + query.len()].to_string(),
+            Style::new().fg(theme.cyan).bold().underlined(),
+        ),
+        Span::styled(text[at + query.len()..].to_string(), Style::new().fg(color)),
+    ]
+}
+
+/// Where the search text sits in the part of the name that is shown bright.
+fn hit(tail: &str, query: &str) -> Option<usize> {
+    if query.is_empty() || !tail.is_ascii() || !query.is_ascii() {
+        return None;
+    }
+
+    tail.to_lowercase().find(&query.to_lowercase())
+}
+
+/// Every distinct reference the pods of a namespace run, with how many run it — a rollout
+/// that stopped half way through shows up as two groups.
+///
+/// The groups keep the same width whatever the row holds, so that the second one starts in
+/// the same place in every row and under the heading. Room for the `+N` of the ones left out
+/// comes out of the last group rather than out of the layout.
+fn deployed_spans(row: &NsRow, theme: &Theme) -> Vec<Span<'static>> {
+    let hidden = row.hidden_deployed;
+    let last = row.deployed.len().saturating_sub(1);
+
+    let mut spans: Vec<Span> = row
+        .deployed
+        .iter()
+        .enumerate()
+        .map(|(index, group)| {
+            let width = match hidden > 0 && index == last {
+                true => GROUP_WIDTH - HIDDEN_WIDTH,
+                false => GROUP_WIDTH,
+            };
+
+            Span::styled(
+                format!("{:<width$}", label(group, width), width = width),
+                Style::new().fg(theme.verdict(group.verdict)),
+            )
+        })
+        .collect();
+
+    if hidden > 0 {
+        spans.push(Span::styled(
+            format!("+{}", hidden),
+            Style::new().fg(theme.dim),
+        ));
+    }
+
+    spans
+}
+
+/// The heading names what the column actually holds. A cluster deployed from releases shows
+/// tags whichever mode is on, so naming it after the mode would be a guess.
+pub fn deployed_title(kind: RefKind) -> &'static str {
+    match kind {
+        RefKind::Commits => "DEPLOYED COMMIT",
+        RefKind::Tags => "DEPLOYED TAG",
+        RefKind::Mixed => "DEPLOYED",
+    }
+}
+
+fn label(group: &Deployed, width: usize) -> String {
+    let text = match group.count > 1 {
+        true => format!("{} ×{}", group.label, group.count),
+        false => group.label.clone(),
+    };
+
+    ellipsize(&text, width.saturating_sub(1))
+}
+
+fn reference_color(row: &NsRow, theme: &Theme) -> Color {
+    match row.verdict {
+        Verdict::Resolving => theme.dim,
+        _ => theme.fg2,
+    }
+}
+
+fn note_color(verdict: Verdict, theme: &Theme) -> Color {
+    match verdict {
+        Verdict::Behind => theme.bad,
+        Verdict::Failed(_) => theme.warn,
+        _ => theme.dim,
+    }
+}
+
+/// The note shares whatever the fixed columns leave with the namespace name, so it has to
+/// cut itself off at the same place the table would.
+/// The six columns of the overview table. The namespace is a fixed length rather than a
+/// share, so that what the cells cut themselves to is what the layout hands them.
+fn columns(name_width: usize) -> [Constraint; 6] {
+    [
+        Constraint::Length(GLYPH),
+        Constraint::Length(name_width as u16),
+        Constraint::Length(PODS),
+        Constraint::Length(DEPLOYED),
+        Constraint::Length(REFERENCE),
+        Constraint::Fill(1),
+    ]
+}
+
+/// How the room the fixed columns leave is split between the namespace and the note: three
+/// fifths to the namespace, as the design has it, the rest to the note.
+///
+/// The namespace column is then laid out as a fixed length rather than a share, so that the
+/// width the cells cut themselves to is the width they actually get — rounding inside the
+/// layout solver is not something to guess at, and being one column out means the last
+/// character of a name disappears without an ellipsis to say so.
+fn flexible(total: u16) -> (usize, usize) {
+    let fixed = GLYPH + PODS + DEPLOYED + REFERENCE + 5 * GAP + CURSOR;
+    let room = total.saturating_sub(fixed) as usize;
+    let name = room * 3 / 5;
+
+    (name, room - name)
+}
+
+fn narrow_name_width(total: u16) -> usize {
+    total.saturating_sub(GLYPH + NARROW_REFERENCE + PODS + 3 * GAP + CURSOR) as usize
+}
+
+pub fn scrollbar(frame: &mut Frame, area: Rect, theme: &Theme, total: usize, offset: usize) {
+    if total <= area.height as usize {
+        return;
+    }
+
+    let mut state = ScrollbarState::new(total).position(offset);
+
+    frame.render_stateful_widget(
+        Scrollbar::new(ScrollbarOrientation::VerticalRight)
+            .begin_symbol(None)
+            .end_symbol(None)
+            .track_symbol(Some(" "))
+            .thumb_symbol("▐")
+            .track_style(Style::new().fg(theme.line))
+            .thumb_style(Style::new().fg(theme.line)),
+        area,
+        &mut state,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use speculoos::prelude::*;
+
+    /// What `Table` hands each column at a given table width: it takes the cursor column off
+    /// the top and lays the rest out itself.
+    fn laid_out(total: u16) -> Vec<u16> {
+        let (name, _) = flexible(total);
+        let area = Rect::new(0, 0, total.saturating_sub(CURSOR), 1);
+
+        Layout::horizontal(columns(name))
+            .spacing(GAP)
+            .split(area)
+            .iter()
+            .map(|column| column.width)
+            .collect()
+    }
+
+    fn row(deployed: Vec<Deployed>, hidden: usize) -> NsRow {
+        NsRow {
+            name: "orchard-gateway".to_string(),
+            prefix: 0,
+            verdict: Verdict::Behind,
+            pods: Some(9),
+            deployed,
+            hidden_deployed: hidden,
+            reference: "4f1c0f2c".to_string(),
+            note: "3 of 9 pods behind".to_string(),
+        }
+    }
+
+    fn group(label: &str, count: usize) -> Deployed {
+        Deployed {
+            label: label.to_string(),
+            count,
+            verdict: Verdict::Behind,
+        }
+    }
+
+    fn width_of(row: &NsRow) -> usize {
+        deployed_spans(row, &Theme::new(None, false))
+            .iter()
+            .map(Span::width)
+            .sum()
+    }
+
+    #[test]
+    fn name_column_is_exactly_as_wide_as_the_names_are_cut_to() {
+        let disagreements: Vec<u16> = (60..=200)
+            .filter(|total| laid_out(*total)[1] as usize != flexible(*total).0)
+            .collect();
+
+        asserting!("a column one narrower than the text was cut to drops a character silently")
+            .that(&disagreements)
+            .is_empty();
+    }
+
+    #[test]
+    fn two_commits_fill_the_column() {
+        let listed = row(vec![group("4f1c0f2c", 17), group("91bd7e40", 4)], 0);
+
+        assert_that!(width_of(&listed)).is_less_than_or_equal_to(DEPLOYED as usize);
+    }
+
+    #[test]
+    fn commits_give_up_room_to_the_count_of_those_left_out() {
+        let listed = row(vec![group("4f1c0f2c", 5), group("91bd7e40", 3)], 3);
+
+        asserting!("the column would otherwise cut off the only sign that there are more")
+            .that(&width_of(&listed))
+            .is_less_than_or_equal_to(DEPLOYED as usize);
+    }
+
+    #[test]
+    fn commits_left_out_are_counted_at_the_end() {
+        let listed = row(vec![group("4f1c0f2c", 5), group("91bd7e40", 3)], 3);
+        let spans = deployed_spans(&listed, &Theme::new(None, false));
+
+        assert_that!(spans.last().map(|span| span.content.to_string()))
+            .is_equal_to(Some("+3".to_string()));
+    }
+}

--- a/src/drawer/terminal.rs
+++ b/src/drawer/terminal.rs
@@ -1,20 +1,26 @@
-use crate::drawer::app::{App, Focus, NamespaceEntry, KEY_HINTS};
+use crate::drawer::app::{App, Input, Pane, Screen};
+use crate::drawer::chrome::{self, MIN_HEIGHT, MIN_WIDTH, WIDE_WIDTH};
+use crate::drawer::theme::Theme;
+use crate::drawer::{detail, overview};
 use crate::errors::MsgError;
-use crate::git::remote::{CommitStatus, RemoteState};
 use crossterm::event::{self, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use ratatui::backend::CrosstermBackend;
-use ratatui::{prelude::*, widgets::*};
+use ratatui::prelude::*;
+use ratatui::widgets::Block;
 use std::time::Duration;
 
+/// Slow enough to keep the process idle, fast enough for the spinner to turn and for
+/// answers from the background to show up as they land.
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
 const PAGE: isize = 10;
 
 pub fn process_frames(
     mut terminal: Terminal<CrosstermBackend<std::io::Stdout>>,
     app: &mut App,
+    theme: &Theme,
 ) -> Result<(), MsgError> {
     loop {
-        if terminal.draw(|frame| draw(frame, app)).is_err() {
+        if terminal.draw(|frame| draw(frame, app, theme)).is_err() {
             return Err(MsgError::new("There was a problem drawing new frame"));
         }
 
@@ -31,11 +37,81 @@ pub fn process_frames(
             }
         }
 
-        app.drain_lookups();
+        app.tick();
 
         if app.should_quit() {
             return Ok(());
         }
+    }
+}
+
+fn draw(frame: &mut Frame, app: &mut App, theme: &Theme) {
+    let area = frame.area();
+    frame.render_widget(
+        Block::new().style(Style::new().bg(theme.bg).fg(theme.fg)),
+        area,
+    );
+
+    if area.width < MIN_WIDTH || area.height < MIN_HEIGHT {
+        chrome::too_small(frame, area, theme);
+        return;
+    }
+
+    let narrow = area.width < WIDE_WIDTH;
+    app.set_narrow(narrow);
+
+    let [head, rest, status, keys] = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Fill(1),
+        Constraint::Length(1),
+        Constraint::Length(1),
+    ])
+    .areas(area);
+
+    frame.render_widget(
+        match narrow {
+            true => chrome::narrow_header(app, theme, head.width),
+            false => chrome::header(app, theme, head.width),
+        },
+        head,
+    );
+
+    // the controls bar belongs to the overview; the detail screen only borrows it to show
+    // the search prompt, and the narrow layout shows counts in its place
+    let searching = app.input() == Input::Search;
+    let body = match narrow || app.screen() == Screen::Overview || searching {
+        true => {
+            let [bar, body] =
+                Layout::vertical([Constraint::Length(1), Constraint::Fill(1)]).areas(rest);
+
+            frame.render_widget(
+                match (searching, narrow) {
+                    (true, _) => chrome::bar(app, theme, bar.width),
+                    (false, true) => chrome::narrow_bar(app, theme, bar.width),
+                    (false, false) => chrome::bar(app, theme, bar.width),
+                },
+                bar,
+            );
+
+            body
+        }
+        false => rest,
+    };
+
+    match (app.screen(), narrow) {
+        (Screen::Overview, false) => overview::draw(frame, body, app, theme),
+        (Screen::Overview, true) => overview::draw_narrow(frame, body, app, theme),
+        (Screen::Detail, wide) => detail::draw(frame, body, app, theme, !wide),
+    }
+
+    frame.render_widget(
+        chrome::status_line(app, theme, status.width, narrow),
+        status,
+    );
+    frame.render_widget(chrome::keys_line(app, theme, keys.width, narrow), keys);
+
+    if app.input() == Input::Help {
+        chrome::help(frame, area, theme);
     }
 }
 
@@ -44,145 +120,72 @@ fn handle_key(app: &mut App, key: KeyEvent) {
         return;
     }
 
+    if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+        app.quit();
+        return;
+    }
+
+    match app.input() {
+        Input::Help => handle_help(app, key),
+        Input::Search => handle_search(app, key),
+        Input::Normal => handle_normal(app, key),
+    }
+}
+
+fn handle_help(app: &mut App, key: KeyEvent) {
     match key.code {
-        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => app.quit(),
-        KeyCode::Char('q') | KeyCode::Esc => app.quit(),
+        KeyCode::Char('?') | KeyCode::Char('q') | KeyCode::Esc => app.toggle_help(),
+        _ => (),
+    }
+}
+
+fn handle_search(app: &mut App, key: KeyEvent) {
+    match key.code {
+        KeyCode::Enter => app.end_search(true),
+        KeyCode::Esc => app.end_search(false),
+        KeyCode::Backspace => app.search_pop(),
+        KeyCode::Up => app.move_selection(-1),
+        KeyCode::Down => app.move_selection(1),
+        KeyCode::Char(symbol) => app.search_push(symbol),
+        _ => (),
+    }
+}
+
+fn handle_normal(app: &mut App, key: KeyEvent) {
+    match key.code {
+        KeyCode::Char('q') => app.quit(),
+        KeyCode::Esc => app.back(),
         KeyCode::Up | KeyCode::Char('k') => app.move_selection(-1),
         KeyCode::Down | KeyCode::Char('j') => app.move_selection(1),
         KeyCode::PageUp => app.move_selection(-PAGE),
         KeyCode::PageDown => app.move_selection(PAGE),
         KeyCode::Home => app.move_selection(isize::MIN),
         KeyCode::End => app.move_selection(isize::MAX),
-        KeyCode::Right | KeyCode::Char('l') | KeyCode::Tab => app.focus_next(),
-        KeyCode::Left | KeyCode::Char('h') | KeyCode::BackTab => app.focus_prev(),
+        KeyCode::Right | KeyCode::Char('l') => match app.screen() {
+            Screen::Overview => app.open_namespace(),
+            Screen::Detail => app.focus_next(),
+        },
+        KeyCode::Left | KeyCode::Char('h') => match (app.screen(), app.pane()) {
+            // the namespace list is not on screen in the narrow layout, so there is nothing
+            // to the left of the pods but the way back
+            (Screen::Detail, Pane::Pods) if app.narrow() => app.back(),
+            (Screen::Detail, Pane::Namespaces) => app.back(),
+            (Screen::Detail, _) => app.focus_prev(),
+            (Screen::Overview, _) => (),
+        },
+        KeyCode::Tab => match app.screen() {
+            Screen::Detail => app.focus_containers(),
+            Screen::Overview => app.open_namespace(),
+        },
+        KeyCode::BackTab => app.focus_prev(),
         KeyCode::Enter => app.activate(),
         KeyCode::Char('m') => app.toggle_mode(),
         KeyCode::Char('r') => app.refresh_selected(),
+        KeyCode::Char('R') => app.relist_pods(),
+        KeyCode::Char('f') => app.cycle_filter(),
+        KeyCode::Char('s') => app.cycle_sort(),
+        KeyCode::Char('/') => app.start_search(),
+        KeyCode::Char('?') => app.toggle_help(),
         _ => (),
-    }
-}
-
-fn draw(frame: &mut Frame, app: &mut App) {
-    let root = Layout::vertical([Constraint::Min(3), Constraint::Length(1)]).split(frame.area());
-    let panes = Layout::horizontal([
-        Constraint::Percentage(30),
-        Constraint::Percentage(35),
-        Constraint::Percentage(35),
-    ])
-    .split(root[0]);
-
-    let focus = app.focus();
-    let ns_items = namespace_items(app);
-    let pod_items = pod_items(app);
-    let cont_items = container_items(app);
-    let ns_title = format!("Namespaces ({})", ns_items.len());
-    let pod_title = format!("Pods ({})", pod_items.len());
-    let cont_title = containers_title(app);
-    let footer = format!("{} · {}", app.footer(), KEY_HINTS);
-
-    frame.render_stateful_widget(
-        list(ns_items, ns_title, focus == Focus::Namespaces),
-        panes[0],
-        app.ns_state(),
-    );
-    frame.render_stateful_widget(
-        list(pod_items, pod_title, focus == Focus::Pods),
-        panes[1],
-        app.pod_state(),
-    );
-    frame.render_stateful_widget(
-        list(cont_items, cont_title, focus == Focus::Containers),
-        panes[2],
-        app.cont_state(),
-    );
-
-    frame.render_widget(
-        Paragraph::new(Line::from(footer).style(Style::new().fg(Color::DarkGray))),
-        root[1],
-    );
-}
-
-fn list(items: Vec<ListItem<'static>>, title: String, focused: bool) -> List<'static> {
-    let mut block = Block::new().borders(Borders::ALL).title(title);
-
-    if focused {
-        block = block
-            .border_style(Style::new().fg(Color::Cyan))
-            .title_style(Style::new().add_modifier(Modifier::BOLD));
-    }
-
-    List::new(items)
-        .block(block)
-        .highlight_style(Style::new().add_modifier(Modifier::REVERSED))
-}
-
-fn namespace_items(app: &App) -> Vec<ListItem<'static>> {
-    app.namespaces()
-        .iter()
-        .map(|entry| item(namespace_label(entry), app.namespace_status(entry)))
-        .collect()
-}
-
-fn namespace_label(entry: &NamespaceEntry) -> String {
-    match &entry.error {
-        Some(_) => format!("{} (unavailable)", entry.name),
-        None => format!("{} ({})", entry.name, entry.pods.len()),
-    }
-}
-
-fn pod_items(app: &App) -> Vec<ListItem<'static>> {
-    let Some(entry) = app.selected_namespace() else {
-        return vec![];
-    };
-
-    entry
-        .pods
-        .iter()
-        .map(|pod| item(pod.name.clone(), app.pod_status(&entry.name, pod)))
-        .collect()
-}
-
-fn container_items(app: &App) -> Vec<ListItem<'static>> {
-    let Some(entry) = app.selected_namespace() else {
-        return vec![];
-    };
-    let Some(pod) = app.selected_pod() else {
-        return vec![];
-    };
-
-    pod.containers
-        .iter()
-        .map(|cont| {
-            item(
-                format!("{}  {}", cont.name, cont.tag().unwrap_or("no tag")),
-                app.container_status(&entry.name, cont),
-            )
-        })
-        .collect()
-}
-
-/// Shows what the pods are being compared against, so a gray pane is explainable.
-fn containers_title(app: &App) -> String {
-    let Some(entry) = app.selected_namespace() else {
-        return "Containers".to_string();
-    };
-
-    match app.remote(&entry.name) {
-        Some(RemoteState::Ready(target)) => format!("Containers · {}", target.label()),
-        Some(RemoteState::Loading) => "Containers · resolving".to_string(),
-        Some(RemoteState::Failed(reason)) => format!("Containers · {}", reason),
-        None => "Containers".to_string(),
-    }
-}
-
-fn item(label: String, status: CommitStatus) -> ListItem<'static> {
-    ListItem::new(Line::from(label)).style(style_for(status))
-}
-
-fn style_for(status: CommitStatus) -> Style {
-    match status {
-        CommitStatus::Latest => Style::new().fg(Color::Green),
-        CommitStatus::Outdated => Style::new().fg(Color::Red),
-        CommitStatus::Unknown => Style::new().fg(Color::DarkGray),
     }
 }

--- a/src/drawer/terminal.rs
+++ b/src/drawer/terminal.rs
@@ -1,150 +1,188 @@
-use crate::caller::browser::open_with_hash;
+use crate::drawer::app::{App, Focus, NamespaceEntry, KEY_HINTS};
 use crate::errors::MsgError;
-use crate::k8s::pods::MyPod;
-use crate::storage::json_storage::JsonStorage;
-use crossterm::event::{self, KeyCode, KeyEventKind};
+use crate::git::remote::{CommitStatus, RemoteState};
+use crossterm::event::{self, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use ratatui::backend::CrosstermBackend;
 use ratatui::{prelude::*, widgets::*};
+use std::time::Duration;
+
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
+const PAGE: isize = 10;
 
 pub fn process_frames(
     mut terminal: Terminal<CrosstermBackend<std::io::Stdout>>,
-    pods: Vec<MyPod>,
-    repos: JsonStorage,
+    app: &mut App,
 ) -> Result<(), MsgError> {
-    let mut current_pod = 0;
-    let mut current_container = 0;
-    let mut pressed = false;
-
     loop {
-        match terminal.draw(|frame| {
-            let layout = Layout::default()
-                .direction(Direction::Horizontal)
-                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
-                .split(frame.size());
-
-            let mut pods_text: Vec<Line> = vec![];
-            let mut conts_text: Vec<Line> = vec![];
-
-            for (i, pod) in pods.iter().enumerate() {
-                let msg = format!("{}", pod.name);
-
-                let line = if i == current_pod && !pressed {
-                    Line::from(msg.on_white().black())
-                } else if i == current_pod && pressed {
-                    Line::from(msg.on_dark_gray().white())
-                } else {
-                    Line::from(msg)
-                };
-                pods_text.push(line);
-
-                if i == current_pod {
-                    for (j, cont) in pod.containers.iter().enumerate() {
-                        let cont_msg = format!("{}", cont.image);
-
-                        let cont_line = if j == current_container && pressed {
-                            Line::from(cont_msg.on_white().black())
-                        } else {
-                            Line::from(cont_msg)
-                        };
-                        conts_text.push(cont_line)
-                    }
-                }
-            }
-            frame.render_widget(
-                Paragraph::new(pods_text).block(Block::new().borders(Borders::ALL).title("Pods")),
-                layout[0],
-            );
-
-            frame.render_widget(
-                Paragraph::new(conts_text)
-                    .block(Block::new().borders(Borders::ALL).title("Containers")),
-                layout[1],
-            );
-        }) {
-            Ok(_) => (),
-            Err(_) => return Err(MsgError::new("There was a problem drawing new frame")),
+        if terminal.draw(|frame| draw(frame, app)).is_err() {
+            return Err(MsgError::new("There was a problem drawing new frame"));
         }
 
-        let polled = match event::poll(std::time::Duration::from_millis(16)) {
+        let polled = match event::poll(POLL_INTERVAL) {
             Ok(x) => x,
             Err(_) => return Err(MsgError::new("There was an error when polling")),
         };
 
         if polled {
-            if let Ok(event::Event::Key(key)) = event::read() {
-                if key.kind == KeyEventKind::Press {
-                    if key.code == KeyCode::Char('q') {
-                        break;
-                    }
-                    if key.code == KeyCode::Up {
-                        if !pressed {
-                            if current_pod > 0 {
-                                current_pod -= 1;
-                            }
-                        } else {
-                            if current_container > 0 {
-                                current_container -= 1;
-                            }
-                        }
-                    }
-                    if key.code == KeyCode::Down {
-                        if !pressed {
-                            if current_pod + 1 < pods.len() {
-                                current_pod += 1;
-                            }
-                        } else {
-                            if current_container + 1 < pods[current_pod].containers.len() {
-                                current_container += 1;
-                            }
-                        }
-                    }
-
-                    if key.code == KeyCode::Enter {
-                        if !pressed {
-                            pressed = true;
-                        } else {
-                            let hash = match pods[current_pod].containers[current_container]
-                                .commit_hash()
-                            {
-                                Ok(x) => x,
-                                Err(e) => return Err(e),
-                            };
-
-                            let url = match repos.get_repo_by_name(&pods[current_pod].namespace) {
-                                Some(x) => &x.url,
-                                None => return Err(MsgError::new("Missing repo in storage")),
-                            };
-
-                            match open_with_hash(&url, &hash) {
-                                Ok(_) => (),
-                                Err(_) => {
-                                    return Err(MsgError::new(
-                                        "There was a problem opening browser",
-                                    ))
-                                }
-                            }
-
-                            break;
-                        }
-                    }
-
-                    if key.code == KeyCode::Right {
-                        if !pressed {
-                            pressed = true;
-                        }
-                    }
-
-                    if key.code == KeyCode::Left {
-                        if pressed {
-                            pressed = false;
-                        }
-                    }
-                }
-            } else {
-                return Err(MsgError::new("There was an error when reading events"));
+            match event::read() {
+                Ok(event::Event::Key(key)) => handle_key(app, key),
+                Ok(_) => (),
+                Err(_) => return Err(MsgError::new("There was an error when reading events")),
             }
         }
+
+        app.drain_lookups();
+
+        if app.should_quit() {
+            return Ok(());
+        }
+    }
+}
+
+fn handle_key(app: &mut App, key: KeyEvent) {
+    if key.kind != KeyEventKind::Press {
+        return;
     }
 
-    Ok(())
+    match key.code {
+        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => app.quit(),
+        KeyCode::Char('q') | KeyCode::Esc => app.quit(),
+        KeyCode::Up | KeyCode::Char('k') => app.move_selection(-1),
+        KeyCode::Down | KeyCode::Char('j') => app.move_selection(1),
+        KeyCode::PageUp => app.move_selection(-PAGE),
+        KeyCode::PageDown => app.move_selection(PAGE),
+        KeyCode::Home => app.move_selection(isize::MIN),
+        KeyCode::End => app.move_selection(isize::MAX),
+        KeyCode::Right | KeyCode::Char('l') | KeyCode::Tab => app.focus_next(),
+        KeyCode::Left | KeyCode::Char('h') | KeyCode::BackTab => app.focus_prev(),
+        KeyCode::Enter => app.activate(),
+        KeyCode::Char('m') => app.toggle_mode(),
+        KeyCode::Char('r') => app.refresh_selected(),
+        _ => (),
+    }
+}
+
+fn draw(frame: &mut Frame, app: &mut App) {
+    let root = Layout::vertical([Constraint::Min(3), Constraint::Length(1)]).split(frame.area());
+    let panes = Layout::horizontal([
+        Constraint::Percentage(30),
+        Constraint::Percentage(35),
+        Constraint::Percentage(35),
+    ])
+    .split(root[0]);
+
+    let focus = app.focus();
+    let ns_items = namespace_items(app);
+    let pod_items = pod_items(app);
+    let cont_items = container_items(app);
+    let ns_title = format!("Namespaces ({})", ns_items.len());
+    let pod_title = format!("Pods ({})", pod_items.len());
+    let cont_title = containers_title(app);
+    let footer = format!("{} · {}", app.footer(), KEY_HINTS);
+
+    frame.render_stateful_widget(
+        list(ns_items, ns_title, focus == Focus::Namespaces),
+        panes[0],
+        app.ns_state(),
+    );
+    frame.render_stateful_widget(
+        list(pod_items, pod_title, focus == Focus::Pods),
+        panes[1],
+        app.pod_state(),
+    );
+    frame.render_stateful_widget(
+        list(cont_items, cont_title, focus == Focus::Containers),
+        panes[2],
+        app.cont_state(),
+    );
+
+    frame.render_widget(
+        Paragraph::new(Line::from(footer).style(Style::new().fg(Color::DarkGray))),
+        root[1],
+    );
+}
+
+fn list(items: Vec<ListItem<'static>>, title: String, focused: bool) -> List<'static> {
+    let mut block = Block::new().borders(Borders::ALL).title(title);
+
+    if focused {
+        block = block
+            .border_style(Style::new().fg(Color::Cyan))
+            .title_style(Style::new().add_modifier(Modifier::BOLD));
+    }
+
+    List::new(items)
+        .block(block)
+        .highlight_style(Style::new().add_modifier(Modifier::REVERSED))
+}
+
+fn namespace_items(app: &App) -> Vec<ListItem<'static>> {
+    app.namespaces()
+        .iter()
+        .map(|entry| item(namespace_label(entry), app.namespace_status(entry)))
+        .collect()
+}
+
+fn namespace_label(entry: &NamespaceEntry) -> String {
+    match &entry.error {
+        Some(_) => format!("{} (unavailable)", entry.name),
+        None => format!("{} ({})", entry.name, entry.pods.len()),
+    }
+}
+
+fn pod_items(app: &App) -> Vec<ListItem<'static>> {
+    let Some(entry) = app.selected_namespace() else {
+        return vec![];
+    };
+
+    entry
+        .pods
+        .iter()
+        .map(|pod| item(pod.name.clone(), app.pod_status(&entry.name, pod)))
+        .collect()
+}
+
+fn container_items(app: &App) -> Vec<ListItem<'static>> {
+    let Some(entry) = app.selected_namespace() else {
+        return vec![];
+    };
+    let Some(pod) = app.selected_pod() else {
+        return vec![];
+    };
+
+    pod.containers
+        .iter()
+        .map(|cont| {
+            item(
+                format!("{}  {}", cont.name, cont.tag().unwrap_or("no tag")),
+                app.container_status(&entry.name, cont),
+            )
+        })
+        .collect()
+}
+
+/// Shows what the pods are being compared against, so a gray pane is explainable.
+fn containers_title(app: &App) -> String {
+    let Some(entry) = app.selected_namespace() else {
+        return "Containers".to_string();
+    };
+
+    match app.remote(&entry.name) {
+        Some(RemoteState::Ready(target)) => format!("Containers · {}", target.label()),
+        Some(RemoteState::Loading) => "Containers · resolving".to_string(),
+        Some(RemoteState::Failed(reason)) => format!("Containers · {}", reason),
+        None => "Containers".to_string(),
+    }
+}
+
+fn item(label: String, status: CommitStatus) -> ListItem<'static> {
+    ListItem::new(Line::from(label)).style(style_for(status))
+}
+
+fn style_for(status: CommitStatus) -> Style {
+    match status {
+        CommitStatus::Latest => Style::new().fg(Color::Green),
+        CommitStatus::Outdated => Style::new().fg(Color::Red),
+        CommitStatus::Unknown => Style::new().fg(Color::DarkGray),
+    }
 }

--- a/src/drawer/theme.rs
+++ b/src/drawer/theme.rs
@@ -1,0 +1,128 @@
+use crate::git::remote::Verdict;
+use crate::k8s::context::Env;
+use ratatui::style::Color;
+
+/// Every colour the interface uses. Built once at start-up: the palette depends on the
+/// cluster, on whether the terminal can do 24-bit colour, and on the colour-blind switch.
+pub struct Theme {
+    pub bg: Color,
+    /// Background of the bars that frame the table.
+    pub bar: Color,
+    /// Background of the key hint line, a shade below the bars.
+    pub keys_bar: Color,
+    pub line: Color,
+    pub selection: Color,
+    pub fg: Color,
+    pub fg2: Color,
+    pub dim: Color,
+    pub faint: Color,
+    pub ok: Color,
+    pub bad: Color,
+    pub warn: Color,
+    pub cyan: Color,
+    /// Colour of the environment badge and of the context name next to it.
+    pub env: Color,
+    pub env_fg: Color,
+    /// Tint of the whole header, so the cluster is visible out of the corner of an eye.
+    pub env_bg: Color,
+}
+
+impl Theme {
+    pub fn new(env: Option<Env>, colorblind: bool) -> Theme {
+        match truecolor() {
+            true => Theme::rgb(env, colorblind),
+            false => Theme::ansi(env, colorblind),
+        }
+    }
+
+    pub fn verdict(&self, verdict: Verdict) -> Color {
+        match verdict {
+            Verdict::InSync => self.ok,
+            Verdict::Behind => self.bad,
+            Verdict::Failed(_) => self.warn,
+            Verdict::Resolving | Verdict::Unknown(_) => self.dim,
+        }
+    }
+
+    fn rgb(env: Option<Env>, colorblind: bool) -> Theme {
+        let (badge, badge_fg, tint) = match env {
+            Some(Env::Prod) => (0xf2617a, 0x170d11, 0x241820),
+            Some(Env::Stage) => (0xe5a95c, 0x191308, 0x231d13),
+            Some(Env::Dev) => (0x7dcfff, 0x0d1620, 0x141d26),
+            None => (0x98a1b8, 0x161923, 0x191d28),
+        };
+
+        Theme {
+            bg: rgb(0x161923),
+            bar: rgb(0x191d28),
+            keys_bar: rgb(0x12151e),
+            line: rgb(0x272d3b),
+            selection: rgb(0x232a38),
+            fg: rgb(0xc8cedd),
+            fg2: rgb(0x98a1b8),
+            dim: rgb(0x69738c),
+            faint: rgb(0x454e63),
+            ok: rgb(match colorblind {
+                true => 0x5cb8f0,
+                false => 0xa3e05c,
+            }),
+            bad: rgb(match colorblind {
+                true => 0xf0883e,
+                false => 0xf2617a,
+            }),
+            warn: rgb(0xe5a95c),
+            cyan: rgb(0x7dcfff),
+            env: rgb(badge),
+            env_fg: rgb(badge_fg),
+            env_bg: rgb(tint),
+        }
+    }
+
+    /// Fallback for terminals that do not announce 24-bit colour: the same roles, drawn
+    /// with the sixteen colours every terminal has, and no background tints to get wrong.
+    fn ansi(env: Option<Env>, colorblind: bool) -> Theme {
+        let badge = match env {
+            Some(Env::Prod) => Color::Red,
+            Some(Env::Stage) => Color::Yellow,
+            Some(Env::Dev) => Color::Cyan,
+            None => Color::Gray,
+        };
+
+        Theme {
+            bg: Color::Reset,
+            bar: Color::Reset,
+            keys_bar: Color::Reset,
+            line: Color::DarkGray,
+            // not DarkGray: dimmed text is DarkGray too, and would vanish on the cursor row
+            selection: Color::Blue,
+            fg: Color::White,
+            fg2: Color::Gray,
+            dim: Color::DarkGray,
+            faint: Color::DarkGray,
+            ok: match colorblind {
+                true => Color::LightBlue,
+                false => Color::Green,
+            },
+            bad: match colorblind {
+                true => Color::LightYellow,
+                false => Color::Red,
+            },
+            warn: Color::Yellow,
+            cyan: Color::Cyan,
+            env: badge,
+            env_fg: Color::Black,
+            env_bg: Color::Reset,
+        }
+    }
+}
+
+fn rgb(hex: u32) -> Color {
+    Color::Rgb((hex >> 16) as u8, (hex >> 8) as u8, hex as u8)
+}
+
+fn truecolor() -> bool {
+    matches!(
+        std::env::var("COLORTERM").as_deref(),
+        Ok("truecolor") | Ok("24bit")
+    )
+}

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,0 +1,1 @@
+pub mod remote;

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -1,0 +1,658 @@
+use crate::errors::MsgError;
+use clap::ValueEnum;
+use std::collections::HashMap;
+use std::process::Command;
+use std::sync::mpsc::Sender;
+use std::thread;
+
+const REFS_TAGS: &str = "refs/tags/";
+/// Suffix `git` puts on the ref that an annotated tag points at.
+const PEELED: &str = "^{}";
+const SHORT_HASH_LEN: usize = 8;
+const MIN_HASH_LEN: usize = 7;
+const MAX_HASH_LEN: usize = 40;
+
+/// What CI baked into an image tag. Branch builds are tagged `<short sha>-<pipeline id>`,
+/// releases `<git tag>-<pipeline id>`, so the same field means different things.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImageRef {
+    Commit(String),
+    Tag(String),
+}
+
+impl ImageRef {
+    pub fn from_image_tag(tag: &str) -> Option<ImageRef> {
+        let reference = strip_pipeline_id(tag);
+        if reference.is_empty() {
+            return None;
+        }
+
+        let looks_like_hash = (MIN_HASH_LEN..=MAX_HASH_LEN).contains(&reference.len())
+            && reference.chars().all(|c| c.is_ascii_hexdigit());
+
+        Some(match looks_like_hash {
+            true => ImageRef::Commit(reference.to_string()),
+            false => ImageRef::Tag(reference.to_string()),
+        })
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            ImageRef::Commit(x) | ImageRef::Tag(x) => x,
+        }
+    }
+}
+
+/// CI appends `-<pipeline id>`; what precedes it is the commit or the tag it built from.
+/// Only the trailing group is dropped, so `v1.0.0-rc1-123` keeps its `-rc1`.
+fn strip_pipeline_id(tag: &str) -> &str {
+    match tag.rsplit_once('-') {
+        Some((head, last))
+            if !head.is_empty() && !last.is_empty() && last.chars().all(|c| c.is_ascii_digit()) =>
+        {
+            head
+        }
+        _ => tag,
+    }
+}
+
+/// What a running pod is expected to match.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, ValueEnum)]
+pub enum Mode {
+    /// Tip of the default branch
+    #[default]
+    Commit,
+    /// Commit the latest tag points at — what production is supposed to run
+    Tag,
+}
+
+impl Mode {
+    pub fn toggled(self) -> Mode {
+        match self {
+            Mode::Commit => Mode::Tag,
+            Mode::Tag => Mode::Commit,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Mode::Commit => "commit",
+            Mode::Tag => "tag",
+        }
+    }
+}
+
+/// Commit the pods are compared against, plus the tag name when there is one.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Target {
+    pub commit: String,
+    pub name: Option<String>,
+    /// Every tag of the repository mapped to its commit. Only filled in tag mode, where it
+    /// tells this repository's tags apart from a sidecar's version and resolves the commit
+    /// of whatever tag a pod actually runs.
+    pub tags: HashMap<String, String>,
+}
+
+impl Target {
+    pub fn label(&self) -> String {
+        let short: String = self.commit.chars().take(SHORT_HASH_LEN).collect();
+
+        match &self.name {
+            Some(name) => format!("{} {}", name, short),
+            None => format!("HEAD {}", short),
+        }
+    }
+
+    /// Commit an image reference stands for, as far as this target can tell.
+    pub fn commit_of(&self, image_ref: &ImageRef) -> Option<String> {
+        match image_ref {
+            ImageRef::Commit(sha) => Some(sha.clone()),
+            ImageRef::Tag(name) => self.tags.get(name).cloned(),
+        }
+    }
+}
+
+/// What is known about a repository's target commit.
+#[derive(Debug, Clone)]
+pub enum RemoteState {
+    Loading,
+    Ready(Target),
+    Failed(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommitStatus {
+    Latest,
+    Outdated,
+    Unknown,
+}
+
+impl CommitStatus {
+    /// Verdict for a group of pods, such as a whole namespace: one lagging pod makes the
+    /// group lag, and the group is up to date only when every pod is known to be. A pod
+    /// nobody can judge leaves the group's verdict open rather than vouching for it.
+    pub fn combined(statuses: impl IntoIterator<Item = CommitStatus>) -> CommitStatus {
+        let mut verdict = CommitStatus::Latest;
+        let mut seen = false;
+
+        for status in statuses {
+            seen = true;
+
+            match status {
+                CommitStatus::Outdated => return CommitStatus::Outdated,
+                CommitStatus::Unknown => verdict = CommitStatus::Unknown,
+                CommitStatus::Latest => (),
+            }
+        }
+
+        match seen {
+            true => verdict,
+            false => CommitStatus::Unknown,
+        }
+    }
+
+    /// Verdict for a single pod: any lagging container drags the pod down, while containers
+    /// nobody can judge — sidecars pinned to their own version — are ignored.
+    pub fn worst_judged(statuses: impl IntoIterator<Item = CommitStatus>) -> CommitStatus {
+        statuses
+            .into_iter()
+            .fold(CommitStatus::Unknown, |worst, status| {
+                match (worst, status) {
+                    (CommitStatus::Outdated, _) | (_, CommitStatus::Outdated) => {
+                        CommitStatus::Outdated
+                    }
+                    (CommitStatus::Latest, _) | (_, CommitStatus::Latest) => CommitStatus::Latest,
+                    _ => CommitStatus::Unknown,
+                }
+            })
+    }
+}
+
+/// Mode the lookup was made in, the namespace it belongs to, and the resolved target.
+pub type LookupResult = (Mode, String, Result<Target, MsgError>);
+
+pub fn resolve(mode: Mode, url: &str) -> Result<Target, MsgError> {
+    match mode {
+        Mode::Commit => latest_commit(url),
+        Mode::Tag => latest_tag(url),
+    }
+}
+
+/// Commit that the remote `HEAD` points at, i.e. the tip of the default branch.
+pub fn latest_commit(url: &str) -> Result<Target, MsgError> {
+    let stdout = ls_remote(&[url, "HEAD"])?;
+
+    match stdout.split_whitespace().next() {
+        Some(sha) => Ok(Target {
+            commit: sha.to_string(),
+            ..Target::default()
+        }),
+        None => Err(MsgError::new("remote returned no HEAD")),
+    }
+}
+
+/// Commit behind the highest version tag. Ordering is left to `git`, whose version sort
+/// puts `v0.1.100` above `v0.1.99` — plain alphabetical would not.
+pub fn latest_tag(url: &str) -> Result<Target, MsgError> {
+    let stdout = ls_remote(&["--tags", "--sort=-v:refname", url])?;
+
+    pick_latest_tag(&stdout)
+}
+
+/// Resolves one repository off-thread; the result arrives through `tx`.
+pub fn spawn_lookup(tx: Sender<LookupResult>, mode: Mode, namespace: String, url: String) {
+    thread::spawn(move || {
+        let result = resolve(mode, &url);
+        let _ = tx.send((mode, namespace, result));
+    });
+}
+
+/// Whether a running image is what the target says it should be.
+///
+/// A commit is compared by hash. A tag is compared by name, and only when the repository
+/// actually has a tag with that name — otherwise it belongs to something else, such as a
+/// sidecar pinned to its own version, and there is nothing to judge.
+pub fn commit_status(image_ref: Option<&ImageRef>, remote: Option<&RemoteState>) -> CommitStatus {
+    let (image_ref, target) = match (image_ref, remote) {
+        (Some(image_ref), Some(RemoteState::Ready(target))) if !image_ref.as_str().is_empty() => {
+            (image_ref, target)
+        }
+        _ => return CommitStatus::Unknown,
+    };
+
+    match image_ref {
+        ImageRef::Commit(hash) => {
+            match target
+                .commit
+                .to_lowercase()
+                .starts_with(&hash.to_lowercase())
+            {
+                true => CommitStatus::Latest,
+                false => CommitStatus::Outdated,
+            }
+        }
+        ImageRef::Tag(name) => match (&target.name, target.tags.contains_key(name)) {
+            (Some(latest), true) => match latest == name {
+                true => CommitStatus::Latest,
+                false => CommitStatus::Outdated,
+            },
+            _ => CommitStatus::Unknown,
+        },
+    }
+}
+
+/// Shells out to `git` so that the user's existing credentials and helpers apply —
+/// no API token needed.
+fn ls_remote(args: &[&str]) -> Result<String, MsgError> {
+    let output = match Command::new("git").arg("ls-remote").args(args).output() {
+        Ok(x) => x,
+        Err(e) => return Err(MsgError::new(&format!("cannot run git: {}", e))),
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let reason = stderr
+            .lines()
+            .find(|l| !l.trim().is_empty())
+            .unwrap_or("git ls-remote failed")
+            .trim()
+            .to_string();
+
+        return Err(MsgError::new(&reason));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Expects `git ls-remote --tags --sort=-v:refname` output: the newest tag comes first,
+/// and an annotated tag also has a `^{}` line carrying the commit it points at.
+fn pick_latest_tag(stdout: &str) -> Result<Target, MsgError> {
+    let refs: Vec<(&str, &str)> = stdout
+        .lines()
+        .filter_map(|line| line.split_once('\t'))
+        .map(|(sha, name)| (sha.trim(), name.trim()))
+        .collect();
+
+    let Some((_, top)) = refs.first() else {
+        return Err(MsgError::new("no tags"));
+    };
+
+    let mut tags: HashMap<String, String> = HashMap::new();
+
+    for (sha, reference) in &refs {
+        let Some(name) = reference.strip_prefix(REFS_TAGS) else {
+            continue;
+        };
+
+        // a peeled entry names the commit, so it wins over the tag object's own sha
+        match name.strip_suffix(PEELED) {
+            Some(peeled) => {
+                tags.insert(peeled.to_string(), sha.to_string());
+            }
+            None => {
+                tags.entry(name.to_string())
+                    .or_insert_with(|| sha.to_string());
+            }
+        }
+    }
+
+    let name = top.strip_prefix(REFS_TAGS).unwrap_or(top);
+    let name = name.strip_suffix(PEELED).unwrap_or(name);
+
+    match tags.get(name) {
+        Some(commit) => Ok(Target {
+            commit: commit.clone(),
+            name: Some(name.to_string()),
+            tags,
+        }),
+        None => Err(MsgError::new("cannot resolve the latest tag")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use speculoos::prelude::*;
+
+    fn sha(short: &str) -> String {
+        format!("{:a<40}", short)
+    }
+
+    fn ls_remote_output(refs: &[(&str, &str)]) -> String {
+        refs.iter()
+            .map(|(commit, reference)| format!("{}\t{}\n", commit, reference))
+            .collect()
+    }
+
+    fn released(refs: &[(&str, &str)]) -> RemoteState {
+        RemoteState::Ready(pick_latest_tag(&ls_remote_output(refs)).unwrap())
+    }
+
+    fn at_commit(commit: &str) -> RemoteState {
+        RemoteState::Ready(Target {
+            commit: commit.to_string(),
+            ..Target::default()
+        })
+    }
+
+    #[test]
+    fn branch_build_is_read_as_a_commit() {
+        let commit = "df811319";
+
+        assert_that!(ImageRef::from_image_tag(&format!("{}-5432284", commit)))
+            .is_equal_to(Some(ImageRef::Commit(commit.to_string())));
+    }
+
+    #[test]
+    fn release_build_is_read_as_a_tag() {
+        let release = "v0.1.3";
+
+        assert_that!(ImageRef::from_image_tag(&format!("{}-5328619", release)))
+            .is_equal_to(Some(ImageRef::Tag(release.to_string())));
+    }
+
+    #[test]
+    fn prerelease_suffix_survives_the_pipeline_id() {
+        let release = "v2.0.0-rc4";
+
+        asserting!("only the trailing numeric group is the pipeline id")
+            .that(&ImageRef::from_image_tag(&format!("{}-5041301", release)))
+            .is_equal_to(Some(ImageRef::Tag(release.to_string())));
+    }
+
+    #[test]
+    fn version_without_a_pipeline_id_is_read_as_a_tag() {
+        let version = "1.30.0";
+
+        assert_that!(ImageRef::from_image_tag(version))
+            .is_equal_to(Some(ImageRef::Tag(version.to_string())));
+    }
+
+    #[test]
+    fn commit_matching_the_target_is_latest() {
+        let short = "bca81e5e";
+        let running = ImageRef::Commit(short.to_string());
+
+        assert_that!(commit_status(Some(&running), Some(&at_commit(&sha(short)))))
+            .is_equal_to(CommitStatus::Latest);
+    }
+
+    #[test]
+    fn commit_differing_from_the_target_is_outdated() {
+        let running = ImageRef::Commit("30f43732".to_string());
+
+        assert_that!(commit_status(
+            Some(&running),
+            Some(&at_commit(&sha("4db5f21d")))
+        ))
+        .is_equal_to(CommitStatus::Outdated);
+    }
+
+    #[test]
+    fn commit_is_compared_ignoring_case() {
+        let short = "F0F1AAFC";
+        let running = ImageRef::Commit(short.to_string());
+
+        assert_that!(commit_status(
+            Some(&running),
+            Some(&at_commit(&sha(&short.to_lowercase())))
+        ))
+        .is_equal_to(CommitStatus::Latest);
+    }
+
+    #[test]
+    fn newest_tag_is_latest() {
+        let newest = "v0.2.3";
+        let remote = released(&[
+            (&sha("11111111"), &format!("refs/tags/{}", newest)),
+            (&sha("22222222"), "refs/tags/v0.2.2"),
+        ]);
+
+        assert_that!(commit_status(
+            Some(&ImageRef::Tag(newest.to_string())),
+            Some(&remote)
+        ))
+        .is_equal_to(CommitStatus::Latest);
+    }
+
+    #[test]
+    fn superseded_tag_is_outdated() {
+        let superseded = "v0.0.30";
+        let remote = released(&[
+            (&sha("33333333"), "refs/tags/v0.0.37"),
+            (&sha("44444444"), &format!("refs/tags/{}", superseded)),
+        ]);
+
+        assert_that!(commit_status(
+            Some(&ImageRef::Tag(superseded.to_string())),
+            Some(&remote)
+        ))
+        .is_equal_to(CommitStatus::Outdated);
+    }
+
+    #[test]
+    fn version_absent_from_the_repository_is_unknown() {
+        let remote = released(&[(&sha("55555555"), "refs/tags/v0.1.1")]);
+        let sidecar = ImageRef::Tag("1.26.2".to_string());
+
+        asserting!("a sidecar version must not be judged against the application's releases")
+            .that(&commit_status(Some(&sidecar), Some(&remote)))
+            .is_equal_to(CommitStatus::Unknown);
+    }
+
+    #[test]
+    fn release_is_unknown_until_tags_are_fetched() {
+        let running = ImageRef::Tag("v0.1.20".to_string());
+
+        asserting!("commit mode has no tag list to resolve a release against")
+            .that(&commit_status(
+                Some(&running),
+                Some(&at_commit(&sha("fa6e1e57"))),
+            ))
+            .is_equal_to(CommitStatus::Unknown);
+    }
+
+    #[test]
+    fn container_without_a_reference_is_unknown() {
+        assert_that!(commit_status(None, Some(&at_commit(&sha("ff8ef895")))))
+            .is_equal_to(CommitStatus::Unknown);
+    }
+
+    #[test]
+    fn missing_lookup_is_unknown() {
+        let running = ImageRef::Commit("c3cc3026".to_string());
+
+        assert_that!(commit_status(Some(&running), None)).is_equal_to(CommitStatus::Unknown);
+    }
+
+    #[test]
+    fn pending_lookup_is_unknown() {
+        let running = ImageRef::Commit("2a4fd3af".to_string());
+
+        assert_that!(commit_status(Some(&running), Some(&RemoteState::Loading)))
+            .is_equal_to(CommitStatus::Unknown);
+    }
+
+    #[test]
+    fn failed_lookup_is_unknown() {
+        let running = ImageRef::Commit("f9860c4b".to_string());
+        let failure = RemoteState::Failed("repository not found".to_string());
+
+        assert_that!(commit_status(Some(&running), Some(&failure)))
+            .is_equal_to(CommitStatus::Unknown);
+    }
+
+    #[test]
+    fn newest_release_is_named_after_its_tag() {
+        let newest = "v1.1.1";
+        let target = pick_latest_tag(&ls_remote_output(&[
+            (&sha("66666666"), &format!("refs/tags/{}", newest)),
+            (&sha("77777777"), "refs/tags/v1.0.9"),
+        ]))
+        .unwrap();
+
+        assert_that!(target.name)
+            .is_some()
+            .is_equal_to(newest.to_string());
+    }
+
+    #[test]
+    fn annotated_tag_resolves_to_the_commit_it_points_at() {
+        let pointed_at = sha("347a96bc");
+        let target = pick_latest_tag(&ls_remote_output(&[
+            (&pointed_at, "refs/tags/v0.2.2^{}"),
+            (&sha("0f835c2a"), "refs/tags/v0.2.2"),
+        ]))
+        .unwrap();
+
+        asserting!("the peeled ref names the commit, the other one names the tag object")
+            .that(&target.commit)
+            .is_equal_to(pointed_at);
+    }
+
+    #[test]
+    fn lightweight_tag_resolves_to_its_own_sha() {
+        let newest = sha("65858222");
+        let target = pick_latest_tag(&ls_remote_output(&[
+            (&newest, "refs/tags/v0.2.0"),
+            (&sha("7d96e0d5"), "refs/tags/v0.1.100^{}"),
+        ]))
+        .unwrap();
+
+        assert_that!(target.commit).is_equal_to(newest);
+    }
+
+    #[test]
+    fn superseded_tag_resolves_to_its_own_commit() {
+        let superseded_at = sha("b5873ad6");
+        let target = pick_latest_tag(&ls_remote_output(&[
+            (&sha("fb262f28"), "refs/tags/v0.2.1"),
+            (&superseded_at, "refs/tags/v0.2.0"),
+        ]))
+        .unwrap();
+
+        assert_that!(target.commit_of(&ImageRef::Tag("v0.2.0".to_string())))
+            .is_some()
+            .is_equal_to(superseded_at);
+    }
+
+    #[test]
+    fn tag_the_repository_does_not_have_resolves_to_nothing() {
+        let target = pick_latest_tag(&ls_remote_output(&[(
+            &sha("88888888"),
+            "refs/tags/v0.1.16",
+        )]))
+        .unwrap();
+
+        assert_that!(target.commit_of(&ImageRef::Tag("v9.9.9".to_string()))).is_none();
+    }
+
+    #[test]
+    fn commit_reference_resolves_to_itself() {
+        let short = "99f6dabd";
+        let target =
+            pick_latest_tag(&ls_remote_output(&[(&sha("aaaaaaa1"), "refs/tags/v0.1.7")])).unwrap();
+
+        assert_that!(target.commit_of(&ImageRef::Commit(short.to_string())))
+            .is_some()
+            .is_equal_to(short.to_string());
+    }
+
+    #[test]
+    fn repository_without_tags_is_an_error() {
+        assert_that!(pick_latest_tag("")).is_err();
+    }
+
+    #[test]
+    fn tagged_target_is_labelled_with_its_tag() {
+        let release = "v0.1.33";
+        let short = "bd812acb";
+        let target = Target {
+            commit: sha(short),
+            name: Some(release.to_string()),
+            ..Target::default()
+        };
+
+        assert_that!(target.label()).is_equal_to(format!("{} {}", release, short));
+    }
+
+    #[test]
+    fn untagged_target_is_labelled_as_head() {
+        let short = "15114a79";
+        let target = Target {
+            commit: sha(short),
+            ..Target::default()
+        };
+
+        assert_that!(target.label()).is_equal_to(format!("HEAD {}", short));
+    }
+
+    #[test]
+    fn group_with_one_lagging_member_is_outdated() {
+        let statuses = [
+            CommitStatus::Latest,
+            CommitStatus::Outdated,
+            CommitStatus::Latest,
+        ];
+
+        assert_that!(CommitStatus::combined(statuses)).is_equal_to(CommitStatus::Outdated);
+    }
+
+    #[test]
+    fn group_where_every_member_is_up_to_date_is_latest() {
+        let statuses = [CommitStatus::Latest, CommitStatus::Latest];
+
+        assert_that!(CommitStatus::combined(statuses)).is_equal_to(CommitStatus::Latest);
+    }
+
+    #[test]
+    fn group_holding_an_unjudged_member_is_unknown() {
+        let statuses = [CommitStatus::Latest, CommitStatus::Unknown];
+
+        asserting!("an unjudged member leaves the group's verdict open")
+            .that(&CommitStatus::combined(statuses))
+            .is_equal_to(CommitStatus::Unknown);
+    }
+
+    #[test]
+    fn lagging_member_outweighs_an_unjudged_one() {
+        let statuses = [CommitStatus::Unknown, CommitStatus::Outdated];
+
+        assert_that!(CommitStatus::combined(statuses)).is_equal_to(CommitStatus::Outdated);
+    }
+
+    #[test]
+    fn empty_group_is_unknown() {
+        assert_that!(CommitStatus::combined([])).is_equal_to(CommitStatus::Unknown);
+    }
+
+    #[test]
+    fn lagging_container_drags_the_pod_down() {
+        let statuses = [CommitStatus::Latest, CommitStatus::Outdated];
+
+        asserting!("an up to date container must not vouch for a lagging one next to it")
+            .that(&CommitStatus::worst_judged(statuses))
+            .is_equal_to(CommitStatus::Outdated);
+    }
+
+    #[test]
+    fn unjudged_container_does_not_hold_the_pod_back() {
+        let statuses = [CommitStatus::Unknown, CommitStatus::Latest];
+
+        asserting!("a sidecar pinned to its own version says nothing about the release")
+            .that(&CommitStatus::worst_judged(statuses))
+            .is_equal_to(CommitStatus::Latest);
+    }
+
+    #[test]
+    fn pod_with_nothing_judgeable_is_unknown() {
+        let statuses = [CommitStatus::Unknown, CommitStatus::Unknown];
+
+        assert_that!(CommitStatus::worst_judged(statuses)).is_equal_to(CommitStatus::Unknown);
+    }
+
+    #[test]
+    fn pod_without_containers_is_unknown() {
+        assert_that!(CommitStatus::worst_judged([])).is_equal_to(CommitStatus::Unknown);
+    }
+}

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -1,4 +1,3 @@
-use crate::errors::MsgError;
 use clap::ValueEnum;
 use std::collections::HashMap;
 use std::process::Command;
@@ -39,6 +38,15 @@ impl ImageRef {
     pub fn as_str(&self) -> &str {
         match self {
             ImageRef::Commit(x) | ImageRef::Tag(x) => x,
+        }
+    }
+
+    /// How the reference is shown in a column: a hash is cut to its short form, a tag
+    /// name is worth reading in full.
+    pub fn label(&self) -> String {
+        match self {
+            ImageRef::Commit(sha) => sha.chars().take(SHORT_HASH_LEN).collect(),
+            ImageRef::Tag(name) => name.clone(),
         }
     }
 }
@@ -94,12 +102,14 @@ pub struct Target {
 }
 
 impl Target {
-    pub fn label(&self) -> String {
-        let short: String = self.commit.chars().take(SHORT_HASH_LEN).collect();
+    pub fn short(&self) -> String {
+        self.commit.chars().take(SHORT_HASH_LEN).collect()
+    }
 
+    pub fn label(&self) -> String {
         match &self.name {
-            Some(name) => format!("{} {}", name, short),
-            None => format!("HEAD {}", short),
+            Some(name) => format!("{} {}", name, self.short()),
+            None => format!("HEAD {}", self.short()),
         }
     }
 
@@ -112,66 +122,135 @@ impl Target {
     }
 }
 
+/// Why a repository has no target. Kept apart from a plain message because the two cases
+/// are not failures of the same kind: a repository without tags is a fact about the
+/// repository, a broken `ls-remote` is a fact about this run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LookupError {
+    NoTags,
+    Git(String),
+}
+
 /// What is known about a repository's target commit.
 #[derive(Debug, Clone)]
 pub enum RemoteState {
     Loading,
     Ready(Target),
+    /// The namespace has no entry in `repos.json`, so there is no repository to ask.
+    Unconfigured,
+    /// Tag mode against a repository that has not been tagged yet.
+    NoTags,
     Failed(String),
 }
 
+/// Which of the five things a row can be. Ordered the way a reader should look at them.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CommitStatus {
-    Latest,
-    Outdated,
-    Unknown,
+pub enum Verdict {
+    Behind,
+    Failed(Failure),
+    Resolving,
+    Unknown(Unresolved),
+    InSync,
 }
 
-impl CommitStatus {
-    /// Verdict for a group of pods, such as a whole namespace: one lagging pod makes the
-    /// group lag, and the group is up to date only when every pod is known to be. A pod
-    /// nobody can judge leaves the group's verdict open rather than vouching for it.
-    pub fn combined(statuses: impl IntoIterator<Item = CommitStatus>) -> CommitStatus {
-        let mut verdict = CommitStatus::Latest;
-        let mut seen = false;
+/// Side that could not answer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Failure {
+    Kube,
+    Git,
+}
 
-        for status in statuses {
-            seen = true;
+/// Why there is nothing to compare. Shown as a short code in its own column, so the five
+/// meanings that used to share one shade of grey can be told apart at a glance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Unresolved {
+    Sidecar,
+    Digest,
+    NoConfig,
+    NoTags,
+    WrongMode,
+    Finished,
+    Empty,
+}
 
-            match status {
-                CommitStatus::Outdated => return CommitStatus::Outdated,
-                CommitStatus::Unknown => verdict = CommitStatus::Unknown,
-                CommitStatus::Latest => (),
-            }
-        }
-
-        match seen {
-            true => verdict,
-            false => CommitStatus::Unknown,
+impl Verdict {
+    /// Carries the same meaning as the colour, so a row still reads in a monochrome
+    /// terminal and under colour blindness.
+    pub fn glyph(self) -> char {
+        match self {
+            Verdict::InSync => '●',
+            Verdict::Behind => '▼',
+            Verdict::Failed(_) => '✗',
+            Verdict::Resolving => '⠙',
+            Verdict::Unknown(_) => '○',
         }
     }
 
-    /// Verdict for a single pod: any lagging container drags the pod down, while containers
-    /// nobody can judge — sidecars pinned to their own version — are ignored.
-    pub fn worst_judged(statuses: impl IntoIterator<Item = CommitStatus>) -> CommitStatus {
-        statuses
-            .into_iter()
-            .fold(CommitStatus::Unknown, |worst, status| {
-                match (worst, status) {
-                    (CommitStatus::Outdated, _) | (_, CommitStatus::Outdated) => {
-                        CommitStatus::Outdated
-                    }
-                    (CommitStatus::Latest, _) | (_, CommitStatus::Latest) => CommitStatus::Latest,
-                    _ => CommitStatus::Unknown,
-                }
-            })
+    pub fn code(self) -> &'static str {
+        match self {
+            Verdict::Failed(Failure::Kube) => "k8s",
+            Verdict::Failed(Failure::Git) => "git",
+            Verdict::Unknown(Unresolved::Sidecar) => "sidecar",
+            Verdict::Unknown(Unresolved::Digest) => "digest",
+            Verdict::Unknown(Unresolved::NoConfig) => "no-cfg",
+            Verdict::Unknown(Unresolved::NoTags) => "no-tags",
+            Verdict::Unknown(Unresolved::WrongMode) => "mode",
+            Verdict::Unknown(Unresolved::Finished) => "done",
+            Verdict::Unknown(Unresolved::Empty) => "no-pods",
+            Verdict::Behind | Verdict::Resolving | Verdict::InSync => "",
+        }
+    }
+
+    /// Sort weight: what somebody opening the tool has to act on comes first.
+    pub fn severity(self) -> u8 {
+        match self {
+            Verdict::Behind => 0,
+            Verdict::Failed(_) => 1,
+            Verdict::Resolving => 2,
+            Verdict::Unknown(_) => 3,
+            Verdict::InSync => 4,
+        }
+    }
+
+    fn worse(self, other: Verdict) -> Verdict {
+        match other.severity() < self.severity() {
+            true => other,
+            false => self,
+        }
+    }
+
+    /// Verdict of a whole made of parts — the containers of a pod, the pods of a namespace.
+    ///
+    /// Anything lagging drags the whole down. Parts nobody can judge are left out as long as
+    /// something else could be judged: a sidecar pinned to its own version says nothing
+    /// about the release, and neither does somebody else's pod that happens to share the
+    /// namespace. Only when nothing at all can be judged does the whole take on the reason
+    /// why.
+    pub fn of_parts(parts: impl IntoIterator<Item = Verdict>) -> Verdict {
+        let mut judged: Option<Verdict> = None;
+        let mut unjudged: Option<Verdict> = None;
+
+        for verdict in parts {
+            let slot = match verdict {
+                Verdict::Unknown(_) => &mut unjudged,
+                _ => &mut judged,
+            };
+            *slot = Some(match slot.take() {
+                Some(current) => current.worse(verdict),
+                None => verdict,
+            });
+        }
+
+        judged
+            .or(unjudged)
+            .unwrap_or(Verdict::Unknown(Unresolved::Empty))
     }
 }
 
 /// Mode the lookup was made in, the namespace it belongs to, and the resolved target.
-pub type LookupResult = (Mode, String, Result<Target, MsgError>);
+pub type LookupResult = (Mode, String, Result<Target, LookupError>);
 
-pub fn resolve(mode: Mode, url: &str) -> Result<Target, MsgError> {
+pub fn resolve(mode: Mode, url: &str) -> Result<Target, LookupError> {
     match mode {
         Mode::Commit => latest_commit(url),
         Mode::Tag => latest_tag(url),
@@ -179,7 +258,7 @@ pub fn resolve(mode: Mode, url: &str) -> Result<Target, MsgError> {
 }
 
 /// Commit that the remote `HEAD` points at, i.e. the tip of the default branch.
-pub fn latest_commit(url: &str) -> Result<Target, MsgError> {
+pub fn latest_commit(url: &str) -> Result<Target, LookupError> {
     let stdout = ls_remote(&[url, "HEAD"])?;
 
     match stdout.split_whitespace().next() {
@@ -187,13 +266,13 @@ pub fn latest_commit(url: &str) -> Result<Target, MsgError> {
             commit: sha.to_string(),
             ..Target::default()
         }),
-        None => Err(MsgError::new("remote returned no HEAD")),
+        None => Err(LookupError::Git("remote returned no HEAD".to_string())),
     }
 }
 
 /// Commit behind the highest version tag. Ordering is left to `git`, whose version sort
 /// puts `v0.1.100` above `v0.1.99` — plain alphabetical would not.
-pub fn latest_tag(url: &str) -> Result<Target, MsgError> {
+pub fn latest_tag(url: &str) -> Result<Target, LookupError> {
     let stdout = ls_remote(&["--tags", "--sort=-v:refname", url])?;
 
     pick_latest_tag(&stdout)
@@ -212,41 +291,49 @@ pub fn spawn_lookup(tx: Sender<LookupResult>, mode: Mode, namespace: String, url
 /// A commit is compared by hash. A tag is compared by name, and only when the repository
 /// actually has a tag with that name — otherwise it belongs to something else, such as a
 /// sidecar pinned to its own version, and there is nothing to judge.
-pub fn commit_status(image_ref: Option<&ImageRef>, remote: Option<&RemoteState>) -> CommitStatus {
-    let (image_ref, target) = match (image_ref, remote) {
-        (Some(image_ref), Some(RemoteState::Ready(target))) if !image_ref.as_str().is_empty() => {
-            (image_ref, target)
-        }
-        _ => return CommitStatus::Unknown,
+pub fn judge(image_ref: Option<&ImageRef>, remote: Option<&RemoteState>) -> Verdict {
+    let target = match remote {
+        None | Some(RemoteState::Loading) => return Verdict::Resolving,
+        Some(RemoteState::Unconfigured) => return Verdict::Unknown(Unresolved::NoConfig),
+        Some(RemoteState::NoTags) => return Verdict::Unknown(Unresolved::NoTags),
+        Some(RemoteState::Failed(_)) => return Verdict::Failed(Failure::Git),
+        Some(RemoteState::Ready(target)) => target,
+    };
+
+    let Some(image_ref) = image_ref else {
+        return Verdict::Unknown(Unresolved::Digest);
     };
 
     match image_ref {
-        ImageRef::Commit(hash) => {
-            match target
-                .commit
-                .to_lowercase()
-                .starts_with(&hash.to_lowercase())
-            {
-                true => CommitStatus::Latest,
-                false => CommitStatus::Outdated,
-            }
-        }
-        ImageRef::Tag(name) => match (&target.name, target.tags.contains_key(name)) {
-            (Some(latest), true) => match latest == name {
-                true => CommitStatus::Latest,
-                false => CommitStatus::Outdated,
+        ImageRef::Commit(hash) => match target
+            .commit
+            .to_lowercase()
+            .starts_with(&hash.to_lowercase())
+        {
+            true => Verdict::InSync,
+            false => Verdict::Behind,
+        },
+        // by commit rather than by name: two tags can point at the same one, and then the
+        // pod is running exactly what the reference asks for
+        ImageRef::Tag(name) => match target.tags.get(name) {
+            Some(commit) => match commit == &target.commit {
+                true => Verdict::InSync,
+                false => Verdict::Behind,
             },
-            _ => CommitStatus::Unknown,
+            // without a tag list there is nothing to look the name up in, which says
+            // something about the mode rather than about the image
+            None if target.tags.is_empty() => Verdict::Unknown(Unresolved::WrongMode),
+            None => Verdict::Unknown(Unresolved::Sidecar),
         },
     }
 }
 
 /// Shells out to `git` so that the user's existing credentials and helpers apply —
 /// no API token needed.
-fn ls_remote(args: &[&str]) -> Result<String, MsgError> {
+fn ls_remote(args: &[&str]) -> Result<String, LookupError> {
     let output = match Command::new("git").arg("ls-remote").args(args).output() {
         Ok(x) => x,
-        Err(e) => return Err(MsgError::new(&format!("cannot run git: {}", e))),
+        Err(e) => return Err(LookupError::Git(format!("cannot run git: {}", e))),
     };
 
     if !output.status.success() {
@@ -258,7 +345,7 @@ fn ls_remote(args: &[&str]) -> Result<String, MsgError> {
             .trim()
             .to_string();
 
-        return Err(MsgError::new(&reason));
+        return Err(LookupError::Git(reason));
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
@@ -266,7 +353,7 @@ fn ls_remote(args: &[&str]) -> Result<String, MsgError> {
 
 /// Expects `git ls-remote --tags --sort=-v:refname` output: the newest tag comes first,
 /// and an annotated tag also has a `^{}` line carrying the commit it points at.
-fn pick_latest_tag(stdout: &str) -> Result<Target, MsgError> {
+fn pick_latest_tag(stdout: &str) -> Result<Target, LookupError> {
     let refs: Vec<(&str, &str)> = stdout
         .lines()
         .filter_map(|line| line.split_once('\t'))
@@ -274,7 +361,7 @@ fn pick_latest_tag(stdout: &str) -> Result<Target, MsgError> {
         .collect();
 
     let Some((_, top)) = refs.first() else {
-        return Err(MsgError::new("no tags"));
+        return Err(LookupError::NoTags);
     };
 
     let mut tags: HashMap<String, String> = HashMap::new();
@@ -305,7 +392,9 @@ fn pick_latest_tag(stdout: &str) -> Result<Target, MsgError> {
             name: Some(name.to_string()),
             tags,
         }),
-        None => Err(MsgError::new("cannot resolve the latest tag")),
+        None => Err(LookupError::Git(
+            "cannot resolve the latest tag".to_string(),
+        )),
     }
 }
 
@@ -369,23 +458,36 @@ mod tests {
     }
 
     #[test]
-    fn commit_matching_the_target_is_latest() {
-        let short = "bca81e5e";
-        let running = ImageRef::Commit(short.to_string());
+    fn commit_reference_is_labelled_by_its_short_hash() {
+        let running = ImageRef::Commit("4f1c0f2c8b3d4e5a".to_string());
 
-        assert_that!(commit_status(Some(&running), Some(&at_commit(&sha(short)))))
-            .is_equal_to(CommitStatus::Latest);
+        assert_that!(running.label()).is_equal_to("4f1c0f2c".to_string());
     }
 
     #[test]
-    fn commit_differing_from_the_target_is_outdated() {
+    fn tag_reference_is_labelled_in_full() {
+        let release = "v10.2.400-rc1";
+
+        asserting!("a version cut in half is not a version")
+            .that(&ImageRef::Tag(release.to_string()).label())
+            .is_equal_to(release.to_string());
+    }
+
+    #[test]
+    fn commit_matching_the_target_is_in_sync() {
+        let short = "bca81e5e";
+        let running = ImageRef::Commit(short.to_string());
+
+        assert_that!(judge(Some(&running), Some(&at_commit(&sha(short)))))
+            .is_equal_to(Verdict::InSync);
+    }
+
+    #[test]
+    fn commit_differing_from_the_target_is_behind() {
         let running = ImageRef::Commit("30f43732".to_string());
 
-        assert_that!(commit_status(
-            Some(&running),
-            Some(&at_commit(&sha("4db5f21d")))
-        ))
-        .is_equal_to(CommitStatus::Outdated);
+        assert_that!(judge(Some(&running), Some(&at_commit(&sha("4db5f21d")))))
+            .is_equal_to(Verdict::Behind);
     }
 
     #[test]
@@ -393,93 +495,119 @@ mod tests {
         let short = "F0F1AAFC";
         let running = ImageRef::Commit(short.to_string());
 
-        assert_that!(commit_status(
+        assert_that!(judge(
             Some(&running),
             Some(&at_commit(&sha(&short.to_lowercase())))
         ))
-        .is_equal_to(CommitStatus::Latest);
+        .is_equal_to(Verdict::InSync);
     }
 
     #[test]
-    fn newest_tag_is_latest() {
+    fn newest_tag_is_in_sync() {
         let newest = "v0.2.3";
         let remote = released(&[
             (&sha("11111111"), &format!("refs/tags/{}", newest)),
             (&sha("22222222"), "refs/tags/v0.2.2"),
         ]);
 
-        assert_that!(commit_status(
+        assert_that!(judge(
             Some(&ImageRef::Tag(newest.to_string())),
             Some(&remote)
         ))
-        .is_equal_to(CommitStatus::Latest);
+        .is_equal_to(Verdict::InSync);
     }
 
     #[test]
-    fn superseded_tag_is_outdated() {
+    fn superseded_tag_is_behind() {
         let superseded = "v0.0.30";
         let remote = released(&[
             (&sha("33333333"), "refs/tags/v0.0.37"),
             (&sha("44444444"), &format!("refs/tags/{}", superseded)),
         ]);
 
-        assert_that!(commit_status(
+        assert_that!(judge(
             Some(&ImageRef::Tag(superseded.to_string())),
             Some(&remote)
         ))
-        .is_equal_to(CommitStatus::Outdated);
+        .is_equal_to(Verdict::Behind);
     }
 
     #[test]
-    fn version_absent_from_the_repository_is_unknown() {
+    fn tag_pointing_at_the_reference_commit_is_in_sync() {
+        let shared = sha("aabbccdd");
+        let remote = released(&[(&shared, "refs/tags/v2.1.0"), (&shared, "refs/tags/v2.0.9")]);
+
+        asserting!("an older tag name on the very commit the reference names is not behind")
+            .that(&judge(
+                Some(&ImageRef::Tag("v2.0.9".to_string())),
+                Some(&remote),
+            ))
+            .is_equal_to(Verdict::InSync);
+    }
+
+    #[test]
+    fn version_absent_from_the_repository_is_a_sidecar() {
         let remote = released(&[(&sha("55555555"), "refs/tags/v0.1.1")]);
         let sidecar = ImageRef::Tag("1.26.2".to_string());
 
         asserting!("a sidecar version must not be judged against the application's releases")
-            .that(&commit_status(Some(&sidecar), Some(&remote)))
-            .is_equal_to(CommitStatus::Unknown);
+            .that(&judge(Some(&sidecar), Some(&remote)))
+            .is_equal_to(Verdict::Unknown(Unresolved::Sidecar));
     }
 
     #[test]
-    fn release_is_unknown_until_tags_are_fetched() {
+    fn release_in_commit_mode_points_at_the_other_mode() {
         let running = ImageRef::Tag("v0.1.20".to_string());
 
-        asserting!("commit mode has no tag list to resolve a release against")
-            .that(&commit_status(
-                Some(&running),
-                Some(&at_commit(&sha("fa6e1e57"))),
-            ))
-            .is_equal_to(CommitStatus::Unknown);
+        asserting!("an application running a release is not a foreign image")
+            .that(&judge(Some(&running), Some(&at_commit(&sha("fa6e1e57")))))
+            .is_equal_to(Verdict::Unknown(Unresolved::WrongMode));
     }
 
     #[test]
-    fn container_without_a_reference_is_unknown() {
-        assert_that!(commit_status(None, Some(&at_commit(&sha("ff8ef895")))))
-            .is_equal_to(CommitStatus::Unknown);
+    fn container_without_a_reference_is_a_digest() {
+        assert_that!(judge(None, Some(&at_commit(&sha("ff8ef895")))))
+            .is_equal_to(Verdict::Unknown(Unresolved::Digest));
     }
 
     #[test]
-    fn missing_lookup_is_unknown() {
+    fn namespace_missing_from_the_config_is_unconfigured() {
         let running = ImageRef::Commit("c3cc3026".to_string());
 
-        assert_that!(commit_status(Some(&running), None)).is_equal_to(CommitStatus::Unknown);
+        assert_that!(judge(Some(&running), Some(&RemoteState::Unconfigured)))
+            .is_equal_to(Verdict::Unknown(Unresolved::NoConfig));
     }
 
     #[test]
-    fn pending_lookup_is_unknown() {
+    fn repository_without_tags_is_reported_as_such() {
+        let running = ImageRef::Tag("v3.1.0".to_string());
+
+        assert_that!(judge(Some(&running), Some(&RemoteState::NoTags)))
+            .is_equal_to(Verdict::Unknown(Unresolved::NoTags));
+    }
+
+    #[test]
+    fn lookup_not_started_yet_is_resolving() {
         let running = ImageRef::Commit("2a4fd3af".to_string());
 
-        assert_that!(commit_status(Some(&running), Some(&RemoteState::Loading)))
-            .is_equal_to(CommitStatus::Unknown);
+        assert_that!(judge(Some(&running), None)).is_equal_to(Verdict::Resolving);
     }
 
     #[test]
-    fn failed_lookup_is_unknown() {
+    fn pending_lookup_is_resolving() {
+        let running = ImageRef::Commit("7bd51e08".to_string());
+
+        assert_that!(judge(Some(&running), Some(&RemoteState::Loading)))
+            .is_equal_to(Verdict::Resolving);
+    }
+
+    #[test]
+    fn broken_lookup_is_a_git_failure() {
         let running = ImageRef::Commit("f9860c4b".to_string());
         let failure = RemoteState::Failed("repository not found".to_string());
 
-        assert_that!(commit_status(Some(&running), Some(&failure)))
-            .is_equal_to(CommitStatus::Unknown);
+        assert_that!(judge(Some(&running), Some(&failure)))
+            .is_equal_to(Verdict::Failed(Failure::Git));
     }
 
     #[test]
@@ -559,8 +687,8 @@ mod tests {
     }
 
     #[test]
-    fn repository_without_tags_is_an_error() {
-        assert_that!(pick_latest_tag("")).is_err();
+    fn repository_without_tags_reports_that_it_has_none() {
+        assert_that!(pick_latest_tag("")).is_err_containing(LookupError::NoTags);
     }
 
     #[test]
@@ -588,71 +716,98 @@ mod tests {
     }
 
     #[test]
-    fn group_with_one_lagging_member_is_outdated() {
-        let statuses = [
-            CommitStatus::Latest,
-            CommitStatus::Outdated,
-            CommitStatus::Latest,
+    fn one_lagging_part_drags_the_whole_down() {
+        let verdicts = [Verdict::InSync, Verdict::Behind, Verdict::InSync];
+
+        asserting!("an up to date part must not vouch for a lagging one next to it")
+            .that(&Verdict::of_parts(verdicts))
+            .is_equal_to(Verdict::Behind);
+    }
+
+    #[test]
+    fn whole_made_of_up_to_date_parts_is_in_sync() {
+        let verdicts = [Verdict::InSync, Verdict::InSync];
+
+        assert_that!(Verdict::of_parts(verdicts)).is_equal_to(Verdict::InSync);
+    }
+
+    #[test]
+    fn part_nobody_can_judge_is_left_out() {
+        let verdicts = [Verdict::InSync, Verdict::Unknown(Unresolved::Sidecar)];
+
+        asserting!("a sidecar, or somebody else's pod in the namespace, says nothing")
+            .that(&Verdict::of_parts(verdicts))
+            .is_equal_to(Verdict::InSync);
+    }
+
+    #[test]
+    fn lagging_part_outweighs_a_broken_lookup() {
+        let verdicts = [Verdict::Failed(Failure::Git), Verdict::Behind];
+
+        asserting!("something to fix outranks something that could not be checked")
+            .that(&Verdict::of_parts(verdicts))
+            .is_equal_to(Verdict::Behind);
+    }
+
+    #[test]
+    fn whole_with_nothing_judgeable_takes_on_the_reason() {
+        let verdicts = [
+            Verdict::Unknown(Unresolved::Digest),
+            Verdict::Unknown(Unresolved::Digest),
         ];
 
-        assert_that!(CommitStatus::combined(statuses)).is_equal_to(CommitStatus::Outdated);
+        assert_that!(Verdict::of_parts(verdicts)).is_equal_to(Verdict::Unknown(Unresolved::Digest));
     }
 
     #[test]
-    fn group_where_every_member_is_up_to_date_is_latest() {
-        let statuses = [CommitStatus::Latest, CommitStatus::Latest];
-
-        assert_that!(CommitStatus::combined(statuses)).is_equal_to(CommitStatus::Latest);
+    fn whole_without_parts_has_nothing_to_compare() {
+        assert_that!(Verdict::of_parts([])).is_equal_to(Verdict::Unknown(Unresolved::Empty));
     }
 
     #[test]
-    fn group_holding_an_unjudged_member_is_unknown() {
-        let statuses = [CommitStatus::Latest, CommitStatus::Unknown];
-
-        asserting!("an unjudged member leaves the group's verdict open")
-            .that(&CommitStatus::combined(statuses))
-            .is_equal_to(CommitStatus::Unknown);
+    fn lagging_row_sorts_above_an_up_to_date_one() {
+        asserting!("the table puts what needs acting on first")
+            .that(&Verdict::Behind.severity())
+            .is_less_than(Verdict::InSync.severity());
     }
 
     #[test]
-    fn lagging_member_outweighs_an_unjudged_one() {
-        let statuses = [CommitStatus::Unknown, CommitStatus::Outdated];
+    fn each_state_has_its_own_glyph() {
+        let glyphs = [
+            Verdict::Behind,
+            Verdict::Failed(Failure::Git),
+            Verdict::Resolving,
+            Verdict::Unknown(Unresolved::Digest),
+            Verdict::InSync,
+        ]
+        .map(Verdict::glyph);
 
-        assert_that!(CommitStatus::combined(statuses)).is_equal_to(CommitStatus::Outdated);
+        let mut unique = glyphs.to_vec();
+        unique.sort_unstable();
+        unique.dedup();
+
+        asserting!("a glyph shared by two states would carry no information")
+            .that(&unique.len())
+            .is_equal_to(glyphs.len());
     }
 
     #[test]
-    fn empty_group_is_unknown() {
-        assert_that!(CommitStatus::combined([])).is_equal_to(CommitStatus::Unknown);
-    }
+    fn every_reason_for_grey_has_its_own_code() {
+        let codes = [
+            Unresolved::Sidecar,
+            Unresolved::Digest,
+            Unresolved::NoConfig,
+            Unresolved::NoTags,
+            Unresolved::WrongMode,
+            Unresolved::Finished,
+            Unresolved::Empty,
+        ]
+        .map(|reason| Verdict::Unknown(reason).code());
 
-    #[test]
-    fn lagging_container_drags_the_pod_down() {
-        let statuses = [CommitStatus::Latest, CommitStatus::Outdated];
+        let mut unique = codes.to_vec();
+        unique.sort_unstable();
+        unique.dedup();
 
-        asserting!("an up to date container must not vouch for a lagging one next to it")
-            .that(&CommitStatus::worst_judged(statuses))
-            .is_equal_to(CommitStatus::Outdated);
-    }
-
-    #[test]
-    fn unjudged_container_does_not_hold_the_pod_back() {
-        let statuses = [CommitStatus::Unknown, CommitStatus::Latest];
-
-        asserting!("a sidecar pinned to its own version says nothing about the release")
-            .that(&CommitStatus::worst_judged(statuses))
-            .is_equal_to(CommitStatus::Latest);
-    }
-
-    #[test]
-    fn pod_with_nothing_judgeable_is_unknown() {
-        let statuses = [CommitStatus::Unknown, CommitStatus::Unknown];
-
-        assert_that!(CommitStatus::worst_judged(statuses)).is_equal_to(CommitStatus::Unknown);
-    }
-
-    #[test]
-    fn pod_without_containers_is_unknown() {
-        assert_that!(CommitStatus::worst_judged([])).is_equal_to(CommitStatus::Unknown);
+        assert_that!(unique.len()).is_equal_to(codes.len());
     }
 }

--- a/src/k8s/client.rs
+++ b/src/k8s/client.rs
@@ -1,0 +1,11 @@
+use crate::errors::MsgError;
+use kube::Client;
+
+/// Single client shared by every namespace lookup — cloning it is cheap,
+/// building it parses the kubeconfig and sets up TLS.
+pub async fn try_default() -> Result<Client, MsgError> {
+    match Client::try_default().await {
+        Ok(client) => Ok(client),
+        Err(_) => Err(MsgError::new("Cannot initialize client")),
+    }
+}

--- a/src/k8s/context.rs
+++ b/src/k8s/context.rs
@@ -1,0 +1,86 @@
+use kube::config::Kubeconfig;
+
+/// Environment a cluster belongs to. Drives the colour of the whole header, so that
+/// production cannot be mistaken for staging out of the corner of an eye.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Env {
+    Prod,
+    Stage,
+    Dev,
+}
+
+impl Env {
+    /// Reads the environment out of a kubeconfig context name, e.g. `orchard-prod` → `Prod`.
+    /// `None` when the name says nothing, in which case no badge is shown at all.
+    pub fn from_context(context: &str) -> Option<Env> {
+        let name = context.to_lowercase();
+
+        // clipped so that `production`, `staging` and `develop` are matched as well
+        [(Env::Prod, "prod"), (Env::Stage, "stag"), (Env::Dev, "dev")]
+            .into_iter()
+            .find(|(_, needle)| name.contains(needle))
+            .map(|(env, _)| env)
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Env::Prod => "PROD",
+            Env::Stage => "STAGE",
+            Env::Dev => "DEV",
+        }
+    }
+}
+
+/// Which cluster the numbers on screen are about.
+#[derive(Debug, Clone, Default)]
+pub struct Cluster {
+    pub context: Option<String>,
+    pub env: Option<Env>,
+}
+
+/// Current context of the kubeconfig. Everything is optional: in-cluster there is no
+/// kubeconfig to read, and the tool still works — it just cannot name the cluster.
+pub fn current() -> Cluster {
+    let context = Kubeconfig::read().ok().and_then(|c| c.current_context);
+    let env = context.as_deref().and_then(Env::from_context);
+
+    Cluster { context, env }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use speculoos::prelude::*;
+
+    #[test]
+    fn production_context_is_recognised() {
+        assert_that!(Env::from_context("orchard-prod")).is_equal_to(Some(Env::Prod));
+    }
+
+    #[test]
+    fn staging_context_is_recognised() {
+        assert_that!(Env::from_context("nimbus-staging-1")).is_equal_to(Some(Env::Stage));
+    }
+
+    #[test]
+    fn development_context_is_recognised() {
+        assert_that!(Env::from_context("dev-cluster")).is_equal_to(Some(Env::Dev));
+    }
+
+    #[test]
+    fn context_name_is_matched_ignoring_case() {
+        assert_that!(Env::from_context("ORCHARD-PROD")).is_equal_to(Some(Env::Prod));
+    }
+
+    #[test]
+    fn production_wins_when_several_words_match() {
+        asserting!("a context deploying prod from a dev jump host is still prod")
+            .that(&Env::from_context("jump-dev-prod-1"))
+            .is_equal_to(Some(Env::Prod));
+    }
+
+    #[test]
+    fn context_naming_no_environment_gets_no_badge() {
+        assert_that!(Env::from_context("minikube")).is_none();
+    }
+}

--- a/src/k8s/mod.rs
+++ b/src/k8s/mod.rs
@@ -1,3 +1,4 @@
 pub mod client;
+pub mod context;
 pub mod ns;
 pub mod pods;

--- a/src/k8s/mod.rs
+++ b/src/k8s/mod.rs
@@ -1,2 +1,3 @@
+pub mod client;
 pub mod ns;
 pub mod pods;

--- a/src/k8s/ns.rs
+++ b/src/k8s/ns.rs
@@ -15,12 +15,7 @@ pub fn get_current_namespace() -> Result<String, MsgError> {
         None => return Err(MsgError::new("Not current context specified")),
     };
 
-    let context = match config
-        .contexts
-        .iter()
-        .filter(|a| a.name == current_context)
-        .next()
-    {
+    let context = match config.contexts.iter().find(|a| a.name == current_context) {
         Some(named) => match named.context.to_owned() {
             Some(x) => x,
             None => return Err(MsgError::new("Couldn't open proper context")),
@@ -30,6 +25,6 @@ pub fn get_current_namespace() -> Result<String, MsgError> {
 
     match context.namespace {
         Some(x) => Ok(x),
-        None => return Err(MsgError::new("Current namespace is not set")),
+        None => Err(MsgError::new("Current namespace is not set")),
     }
 }

--- a/src/k8s/pods.rs
+++ b/src/k8s/pods.rs
@@ -1,10 +1,37 @@
 use crate::errors::MsgError;
 use crate::git::remote::ImageRef;
-use k8s_openapi::api::core::v1::Pod;
+use crate::text::short_duration;
+use k8s_openapi::api::core::v1::{Pod, PodStatus};
+use k8s_openapi::chrono::{DateTime, Utc};
 use kube::{
     api::{Api, ListParams},
     Client,
 };
+
+const UNKNOWN_PHASE: &str = "Unknown";
+const TERMINATING: &str = "Terminating";
+const RUNNING: &str = "Running";
+
+/// Pod states nobody has to look at: it runs, it is on its way in or out, or it is a job
+/// pod that has done its work — normal for anything a CronJob leaves behind.
+const CALM: [&str; 7] = [
+    RUNNING,
+    "Completed",
+    "Succeeded",
+    "Pending",
+    "ContainerCreating",
+    "PodInitializing",
+    TERMINATING,
+];
+
+/// Phases a pod reaches once it has stopped running for good. A pod of a Deployment never
+/// gets there — its restart policy is `Always` — so this is what a Job leaves behind.
+const FINISHED: [&str; 2] = ["Succeeded", "Failed"];
+
+/// Whether a pod's state is one to leave alone, as opposed to one worth a colour.
+pub fn is_calm(status: &str) -> bool {
+    CALM.contains(&status)
+}
 
 pub struct MyContainer {
     pub name: String,
@@ -16,12 +43,12 @@ impl MyContainer {
         MyContainer { name, image }
     }
 
-    /// Image without the registry and project path, e.g. `usage-api:24e8b66c-5409306`.
+    /// Image without the registry and project path, e.g. `orchard-gateway:3ac91b7e-8103771`.
     pub fn short_image(&self) -> &str {
         self.image.rsplit('/').next().unwrap_or(&self.image)
     }
 
-    /// Tag the image is pinned to, e.g. `24e8b66c-5409306`.
+    /// Tag the image is pinned to, e.g. `3ac91b7e-8103771`.
     ///
     /// `None` for an image pinned by digest, where the part after the colon is the digest
     /// rather than a tag.
@@ -44,15 +71,59 @@ pub struct MyPod {
     pub name: String,
     pub namespace: String,
     pub containers: Vec<MyContainer>,
+    /// What `kubectl` shows in its STATUS column: a waiting container's reason if there is
+    /// one, otherwise the phase. A pod stuck in `CrashLoopBackOff` next to a lagging
+    /// commit explains a rollout that never finished.
+    pub status: String,
+    pub restarts: i32,
+    pub ready: usize,
+    pub created: Option<DateTime<Utc>>,
+    /// The pod has run its course and is not deploying anything any more. What a CronJob
+    /// leaves behind ran the code that was current at the time, and says nothing about what
+    /// is deployed now.
+    pub finished: bool,
 }
 
 impl MyPod {
-    fn new(name: String, namespace: String, containers: Vec<MyContainer>) -> MyPod {
+    fn from_pod(pod: Pod, namespace: &str) -> MyPod {
+        let status = status_text(&pod);
+        let restarts = restart_count(pod.status.as_ref());
+        let ready = ready_count(pod.status.as_ref());
+        let finished = has_finished(pod.status.as_ref());
+
+        let containers = pod
+            .spec
+            .map(|spec| spec.containers)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|cont| MyContainer::new(cont.name, cont.image.unwrap_or_default()))
+            .collect();
+
         MyPod {
-            name,
-            namespace,
+            name: pod.metadata.name.unwrap_or_default(),
+            namespace: pod
+                .metadata
+                .namespace
+                .unwrap_or_else(|| namespace.to_string()),
             containers,
+            status,
+            restarts,
+            ready,
+            created: pod.metadata.creation_timestamp.map(|time| time.0),
+            finished,
         }
+    }
+
+    /// How long the pod has been around, in the compact shape `kubectl` uses.
+    pub fn age(&self, now: DateTime<Utc>) -> Option<String> {
+        let created = self.created?;
+
+        Some(short_duration((now - created).num_seconds()))
+    }
+
+    /// Ready containers over total, e.g. `2/2`.
+    pub fn readiness(&self) -> String {
+        format!("{}/{}", self.ready, self.containers.len())
     }
 
     pub async fn get_pods_by_ns(client: &Client, namespace: &str) -> Result<Vec<MyPod>, MsgError> {
@@ -60,68 +131,170 @@ impl MyPod {
 
         let pods = match pods_api.list(&ListParams::default()).await {
             Ok(x) => x,
-            Err(_) => return Err(MsgError::new("Cannot list pods")),
+            Err(e) => return Err(MsgError::new(&list_error(e))),
         };
 
-        let mut my_pods: Vec<MyPod> = vec![];
-
-        for pod in pods {
-            let pod_name = pod.metadata.name.unwrap_or_default();
-
-            let pod_ns = pod
-                .metadata
-                .namespace
-                .unwrap_or_else(|| namespace.to_string());
-
-            let pod_containers = pod.spec.map(|spec| spec.containers).unwrap_or_default();
-
-            let containers: Vec<MyContainer> = pod_containers
-                .into_iter()
-                .map(|cont| MyContainer::new(cont.name, cont.image.unwrap_or_default()))
-                .collect();
-
-            my_pods.push(MyPod::new(pod_name, pod_ns, containers))
-        }
-
-        Ok(my_pods)
+        Ok(pods
+            .into_iter()
+            .map(|pod| MyPod::from_pod(pod, namespace))
+            .collect())
     }
+}
+
+/// Keeps only the part of a kube error worth a table cell: the API reason such as
+/// `forbidden`, not the whole request context.
+fn list_error(error: kube::Error) -> String {
+    match error {
+        kube::Error::Api(response) if !response.reason.is_empty() => response.reason.to_lowercase(),
+        kube::Error::Api(response) => response.message,
+        other => other.to_string(),
+    }
+}
+
+fn status_text(pod: &Pod) -> String {
+    if pod.metadata.deletion_timestamp.is_some() {
+        return TERMINATING.to_string();
+    }
+
+    let status = pod.status.as_ref();
+
+    waiting_reason(status)
+        .or_else(|| terminated_reason(status))
+        .or_else(|| status.and_then(|s| s.phase.clone()))
+        .unwrap_or_else(|| UNKNOWN_PHASE.to_string())
+}
+
+fn waiting_reason(status: Option<&PodStatus>) -> Option<String> {
+    container_statuses(status)?
+        .iter()
+        .find_map(|c| c.state.as_ref()?.waiting.as_ref()?.reason.clone())
+}
+
+fn terminated_reason(status: Option<&PodStatus>) -> Option<String> {
+    container_statuses(status)?
+        .iter()
+        .find_map(|c| c.state.as_ref()?.terminated.as_ref()?.reason.clone())
+}
+
+fn container_statuses(
+    status: Option<&PodStatus>,
+) -> Option<&Vec<k8s_openapi::api::core::v1::ContainerStatus>> {
+    status?.container_statuses.as_ref()
+}
+
+fn has_finished(status: Option<&PodStatus>) -> bool {
+    status
+        .and_then(|s| s.phase.as_deref())
+        .is_some_and(|phase| FINISHED.contains(&phase))
+}
+
+fn restart_count(status: Option<&PodStatus>) -> i32 {
+    container_statuses(status)
+        .map(|list| list.iter().map(|c| c.restart_count).sum())
+        .unwrap_or_default()
+}
+
+fn ready_count(status: Option<&PodStatus>) -> usize {
+    container_statuses(status)
+        .map(|list| list.iter().filter(|c| c.ready).count())
+        .unwrap_or_default()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use k8s_openapi::api::core::v1::{
+        ContainerState, ContainerStateTerminated, ContainerStateWaiting, ContainerStatus, PodSpec,
+    };
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
+    use k8s_openapi::chrono::TimeZone;
     use speculoos::prelude::*;
 
     fn container(image: &str) -> MyContainer {
         MyContainer::new("app".to_string(), image.to_string())
     }
 
+    fn waiting(reason: &str) -> ContainerStatus {
+        ContainerStatus {
+            state: Some(ContainerState {
+                waiting: Some(ContainerStateWaiting {
+                    reason: Some(reason.to_string()),
+                    ..ContainerStateWaiting::default()
+                }),
+                ..ContainerState::default()
+            }),
+            ..ContainerStatus::default()
+        }
+    }
+
+    fn terminated(reason: &str) -> ContainerStatus {
+        ContainerStatus {
+            state: Some(ContainerState {
+                terminated: Some(ContainerStateTerminated {
+                    reason: Some(reason.to_string()),
+                    ..ContainerStateTerminated::default()
+                }),
+                ..ContainerState::default()
+            }),
+            ..ContainerStatus::default()
+        }
+    }
+
+    fn restarted(count: i32, is_ready: bool) -> ContainerStatus {
+        ContainerStatus {
+            restart_count: count,
+            ready: is_ready,
+            ..ContainerStatus::default()
+        }
+    }
+
+    fn pod(phase: &str, statuses: Vec<ContainerStatus>) -> Pod {
+        Pod {
+            status: Some(PodStatus {
+                phase: Some(phase.to_string()),
+                container_statuses: Some(statuses),
+                ..PodStatus::default()
+            }),
+            ..Pod::default()
+        }
+    }
+
+    fn at(year: i32, month: u32, day: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(year, month, day, 12, 0, 0).unwrap()
+    }
+
     #[test]
     fn branch_build_carries_a_commit() {
-        let commit = "8745ffc5";
-        let cont = container(&format!("registry.example/admin-api:{}-5392582", commit));
+        let commit = "3ac91b7e";
+        let cont = container(&format!(
+            "registry.example/orchard-gateway:{}-8103771",
+            commit
+        ));
 
         assert_that!(cont.image_ref()).is_equal_to(Some(ImageRef::Commit(commit.to_string())));
     }
 
     #[test]
     fn release_build_carries_a_tag() {
-        let release = "v0.44.3";
-        let cont = container(&format!("registry.example/public-api:{}-5325504", release));
+        let release = "v3.7.1";
+        let cont = container(&format!(
+            "registry.example/orchard-ledger-api:{}-8203114",
+            release
+        ));
 
         assert_that!(cont.image_ref()).is_equal_to(Some(ImageRef::Tag(release.to_string())));
     }
 
     #[test]
     fn image_without_a_tag_has_no_reference() {
-        let cont = container("registry.example/products/keppel");
+        let cont = container("registry.example/products/driftwood");
 
         assert_that!(cont.image_ref()).is_none();
     }
 
     #[test]
     fn registry_port_is_not_read_as_a_tag() {
-        let cont = container("registry.example:5000/mellivora/npm-component");
+        let cont = container("registry.example:5000/nimbus/cache-component");
 
         asserting!("the port belongs to the registry host")
             .that(&cont.tag())
@@ -130,8 +303,11 @@ mod tests {
 
     #[test]
     fn image_pinned_by_digest_has_no_tag() {
-        let digest = "sha256:2424c1850714a4d94666ec928e24d86de958646737b1d113f5b2207be44d37d8";
-        let cont = container(&format!("registry.example/debian-component@{}", digest));
+        let digest = "sha256:0b7e19f4a3c2d85610fe4477bb90d1c6e5382af0947dc61b8e2f5a3049cd7f12";
+        let cont = container(&format!(
+            "registry.example/nimbus-index-component@{}",
+            digest
+        ));
 
         asserting!("a digest is not a tag")
             .that(&cont.tag())
@@ -140,17 +316,148 @@ mod tests {
 
     #[test]
     fn tag_is_the_part_after_the_colon() {
-        let tag = "1885c684-5432308";
-        let cont = container(&format!("registry.example/rpm-component:{}", tag));
+        let tag = "9d02f4ab-7710455";
+        let cont = container(&format!("registry.example/tulip-mailer:{}", tag));
 
         assert_that!(cont.tag()).is_some().is_equal_to(tag);
     }
 
     #[test]
     fn short_image_drops_the_registry() {
-        let image = "pypi-component:99f6dabd-5432278";
+        let image = "pigeon-post:5f3c17d9-7710462";
         let cont = container(&format!("registry.example/products/{}", image));
 
         assert_that!(cont.short_image()).is_equal_to(image);
+    }
+
+    #[test]
+    fn healthy_pod_reports_its_phase() {
+        let ready = MyPod::from_pod(pod(RUNNING, vec![restarted(0, true)]), "orchard-gateway");
+
+        assert_that!(ready.status).is_equal_to(RUNNING.to_string());
+    }
+
+    #[test]
+    fn waiting_container_names_what_holds_the_pod_back() {
+        let crashing = "CrashLoopBackOff";
+        let stuck = MyPod::from_pod(pod(RUNNING, vec![waiting(crashing)]), "driftwood");
+
+        asserting!("the phase would still say Running while nothing works")
+            .that(&stuck.status)
+            .is_equal_to(crashing.to_string());
+    }
+
+    #[test]
+    fn finished_container_reports_why_it_stopped() {
+        let finished =
+            MyPod::from_pod(pod("Succeeded", vec![terminated("Completed")]), "driftwood");
+
+        assert_that!(finished.status).is_equal_to("Completed".to_string());
+    }
+
+    #[test]
+    fn pod_being_deleted_is_terminating() {
+        let mut leaving = pod(RUNNING, vec![restarted(0, true)]);
+        leaving.metadata.deletion_timestamp = Some(Time(at(2026, 7, 20)));
+
+        assert_that!(MyPod::from_pod(leaving, "driftwood").status)
+            .is_equal_to(TERMINATING.to_string());
+    }
+
+    #[test]
+    fn pod_without_any_status_is_unknown() {
+        let bare = MyPod::from_pod(Pod::default(), "nimbus-index-component");
+
+        assert_that!(bare.status).is_equal_to(UNKNOWN_PHASE.to_string());
+    }
+
+    #[test]
+    fn finished_job_pod_needs_no_attention() {
+        asserting!("a pod a CronJob left behind has done nothing wrong")
+            .that(&is_calm("Completed"))
+            .is_true();
+    }
+
+    #[test]
+    fn starting_pod_needs_no_attention() {
+        assert_that!(is_calm("ContainerCreating")).is_true();
+    }
+
+    #[test]
+    fn crash_looping_pod_is_worth_a_colour() {
+        assert_that!(is_calm("CrashLoopBackOff")).is_false();
+    }
+
+    #[test]
+    fn pod_that_could_not_pull_its_image_is_worth_a_colour() {
+        assert_that!(is_calm("ImagePullBackOff")).is_false();
+    }
+
+    #[test]
+    fn job_pod_that_ran_its_course_is_finished() {
+        let done = MyPod::from_pod(
+            pod("Succeeded", vec![terminated("Completed")]),
+            "tulip-mailer",
+        );
+
+        asserting!("it deploys nothing any more, whatever it once ran")
+            .that(&done.finished)
+            .is_true();
+    }
+
+    #[test]
+    fn serving_pod_is_not_finished() {
+        let serving = MyPod::from_pod(pod(RUNNING, vec![restarted(0, true)]), "orchard-gateway");
+
+        assert_that!(serving.finished).is_false();
+    }
+
+    #[test]
+    fn crashing_pod_is_not_finished() {
+        let crashing =
+            MyPod::from_pod(pod(RUNNING, vec![waiting("CrashLoopBackOff")]), "driftwood");
+
+        asserting!("it is still trying, and it is still what the namespace runs")
+            .that(&crashing.finished)
+            .is_false();
+    }
+
+    #[test]
+    fn restarts_are_summed_over_the_containers() {
+        let flapping = MyPod::from_pod(
+            pod(RUNNING, vec![restarted(5, true), restarted(2, true)]),
+            "orchard-ledger-api",
+        );
+
+        assert_that!(flapping.restarts).is_equal_to(7);
+    }
+
+    #[test]
+    fn readiness_counts_only_the_ready_containers() {
+        let mut half = pod(RUNNING, vec![restarted(0, true), restarted(3, false)]);
+        half.spec = Some(PodSpec {
+            containers: vec![Default::default(), Default::default()],
+            ..PodSpec::default()
+        });
+
+        assert_that!(MyPod::from_pod(half, "orchard-ledger-api").readiness())
+            .is_equal_to("1/2".to_string());
+    }
+
+    #[test]
+    fn pod_without_a_creation_time_has_no_age() {
+        let bare = MyPod::from_pod(Pod::default(), "tulip-mailer");
+
+        assert_that!(bare.age(at(2026, 7, 25))).is_none();
+    }
+
+    #[test]
+    fn age_is_counted_from_the_creation_time() {
+        let mut born = pod(RUNNING, vec![]);
+        born.metadata.creation_timestamp = Some(Time(at(2026, 7, 19)));
+
+        assert_that!(MyPod::from_pod(born, "tulip-mailer").age(at(2026, 7, 25)))
+            .is_some()
+            .is_equal_to("6d".to_string());
     }
 }

--- a/src/k8s/pods.rs
+++ b/src/k8s/pods.rs
@@ -1,4 +1,5 @@
 use crate::errors::MsgError;
+use crate::git::remote::ImageRef;
 use k8s_openapi::api::core::v1::Pod;
 use kube::{
     api::{Api, ListParams},
@@ -15,16 +16,27 @@ impl MyContainer {
         MyContainer { name, image }
     }
 
-    pub fn commit_hash(&self) -> Result<String, MsgError> {
-        let hash = match self.image.split(":").nth(1) {
-            Some(tag) => match tag.split("-").nth(0) {
-                Some(x) => x,
-                None => return Err(MsgError::new("Wrong tag format")),
-            },
-            None => return Err(MsgError::new("Missing tag in image")),
-        };
+    /// Image without the registry and project path, e.g. `usage-api:24e8b66c-5409306`.
+    pub fn short_image(&self) -> &str {
+        self.image.rsplit('/').next().unwrap_or(&self.image)
+    }
 
-        Ok(hash.to_string())
+    /// Tag the image is pinned to, e.g. `24e8b66c-5409306`.
+    ///
+    /// `None` for an image pinned by digest, where the part after the colon is the digest
+    /// rather than a tag.
+    pub fn tag(&self) -> Option<&str> {
+        let image = self.short_image();
+
+        match image.contains('@') {
+            true => None,
+            false => Some(image.rsplit_once(':')?.1),
+        }
+    }
+
+    /// What the image was built from, as far as the tag tells.
+    pub fn image_ref(&self) -> Option<ImageRef> {
+        ImageRef::from_image_tag(self.tag()?)
     }
 }
 
@@ -43,13 +55,8 @@ impl MyPod {
         }
     }
 
-    pub async fn get_pods_by_ns(namespace: String) -> Result<Vec<MyPod>, MsgError> {
-        let client = match Client::try_default().await {
-            Ok(x) => x,
-            Err(_) => return Err(MsgError::new("Cannot initialize client")),
-        };
-
-        let pods_api: Api<Pod> = Api::namespaced(client, &namespace);
+    pub async fn get_pods_by_ns(client: &Client, namespace: &str) -> Result<Vec<MyPod>, MsgError> {
+        let pods_api: Api<Pod> = Api::namespaced(client.clone(), namespace);
 
         let pods = match pods_api.list(&ListParams::default()).await {
             Ok(x) => x,
@@ -59,27 +66,91 @@ impl MyPod {
         let mut my_pods: Vec<MyPod> = vec![];
 
         for pod in pods {
-            let mut containers: Vec<MyContainer> = vec![];
-
             let pod_name = pod.metadata.name.unwrap_or_default();
 
-            let pod_ns = pod.metadata.namespace.unwrap_or_default();
+            let pod_ns = pod
+                .metadata
+                .namespace
+                .unwrap_or_else(|| namespace.to_string());
 
-            let pod_containers = match pod.spec {
-                Some(spec) => spec.containers,
-                None => return Err(MsgError::new("Missing spec")),
-            };
+            let pod_containers = pod.spec.map(|spec| spec.containers).unwrap_or_default();
 
-            for cont in pod_containers {
-                let cont_image = cont.image.unwrap_or_default();
-                let cont_name = cont.name;
-
-                containers.push(MyContainer::new(cont_name, cont_image));
-            }
+            let containers: Vec<MyContainer> = pod_containers
+                .into_iter()
+                .map(|cont| MyContainer::new(cont.name, cont.image.unwrap_or_default()))
+                .collect();
 
             my_pods.push(MyPod::new(pod_name, pod_ns, containers))
         }
 
         Ok(my_pods)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use speculoos::prelude::*;
+
+    fn container(image: &str) -> MyContainer {
+        MyContainer::new("app".to_string(), image.to_string())
+    }
+
+    #[test]
+    fn branch_build_carries_a_commit() {
+        let commit = "8745ffc5";
+        let cont = container(&format!("registry.example/admin-api:{}-5392582", commit));
+
+        assert_that!(cont.image_ref()).is_equal_to(Some(ImageRef::Commit(commit.to_string())));
+    }
+
+    #[test]
+    fn release_build_carries_a_tag() {
+        let release = "v0.44.3";
+        let cont = container(&format!("registry.example/public-api:{}-5325504", release));
+
+        assert_that!(cont.image_ref()).is_equal_to(Some(ImageRef::Tag(release.to_string())));
+    }
+
+    #[test]
+    fn image_without_a_tag_has_no_reference() {
+        let cont = container("registry.example/products/keppel");
+
+        assert_that!(cont.image_ref()).is_none();
+    }
+
+    #[test]
+    fn registry_port_is_not_read_as_a_tag() {
+        let cont = container("registry.example:5000/mellivora/npm-component");
+
+        asserting!("the port belongs to the registry host")
+            .that(&cont.tag())
+            .is_none();
+    }
+
+    #[test]
+    fn image_pinned_by_digest_has_no_tag() {
+        let digest = "sha256:2424c1850714a4d94666ec928e24d86de958646737b1d113f5b2207be44d37d8";
+        let cont = container(&format!("registry.example/debian-component@{}", digest));
+
+        asserting!("a digest is not a tag")
+            .that(&cont.tag())
+            .is_none();
+    }
+
+    #[test]
+    fn tag_is_the_part_after_the_colon() {
+        let tag = "1885c684-5432308";
+        let cont = container(&format!("registry.example/rpm-component:{}", tag));
+
+        assert_that!(cont.tag()).is_some().is_equal_to(tag);
+    }
+
+    #[test]
+    fn short_image_drops_the_registry() {
+        let image = "pypi-component:99f6dabd-5432278";
+        let cont = container(&format!("registry.example/products/{}", image));
+
+        assert_that!(cont.short_image()).is_equal_to(image);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,5 +2,6 @@ pub mod caller;
 pub mod config;
 pub mod drawer;
 pub mod errors;
+pub mod git;
 pub mod k8s;
 pub mod storage;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,4 @@ pub mod errors;
 pub mod git;
 pub mod k8s;
 pub mod storage;
+pub mod text;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,11 +3,15 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
     ExecutableCommand,
 };
+use futures::future::join_all;
 use giter::config::config::Args;
+use giter::drawer::app::{App, NamespaceEntry};
 use giter::drawer::terminal::process_frames;
-use giter::k8s::ns::get_current_namespace;
+use giter::k8s::client;
 use giter::k8s::pods::MyPod;
+use giter::storage::common::Storage;
 use giter::storage::json_storage::JsonStorage;
+use kube::Client;
 use ratatui::prelude::*;
 use std::io::{stdout, Result};
 
@@ -15,32 +19,27 @@ use std::io::{stdout, Result};
 async fn main() -> Result<()> {
     let args = Args::parse();
 
-    let repos: JsonStorage = match JsonStorage::new(args.storage_path.leak()) {
+    let repos: JsonStorage = match JsonStorage::new(&args.storage_path) {
         Ok(x) => x,
-        Err(e) => {
-            eprintln!("{}", e.to_string());
-            std::process::exit(1);
-        }
+        Err(e) => fail(&e.to_string()),
     };
 
-    let current_ns: String = match args.namespace {
-        Some(x) => x,
-        None => match get_current_namespace() {
-            Ok(x) => x,
-            Err(e) => {
-                eprintln!("{}", e.details);
-                std::process::exit(1);
-            }
-        },
+    let names: Vec<String> = match args.namespace {
+        Some(ns) => vec![ns],
+        None => repos.list_repos().iter().map(|r| r.name.clone()).collect(),
     };
 
-    let pods = match MyPod::get_pods_by_ns(current_ns).await {
+    if names.is_empty() {
+        fail(&format!("No repos found in {}", args.storage_path));
+    }
+
+    let kube_client: Client = match client::try_default().await {
         Ok(x) => x,
-        Err(e) => {
-            eprintln!("{}", e.details);
-            std::process::exit(1);
-        }
+        Err(e) => fail(&e.details),
     };
+
+    let namespaces = collect_namespaces(&kube_client, names).await;
+    let mut app = App::new(namespaces, repos, args.mode);
 
     stdout().execute(EnterAlternateScreen)?;
     enable_raw_mode()?;
@@ -48,7 +47,7 @@ async fn main() -> Result<()> {
         Terminal::new(CrosstermBackend::new(stdout()))?;
     terminal.clear()?;
 
-    let error_msg = match process_frames(terminal, pods, repos) {
+    let error_msg = match process_frames(terminal, &mut app) {
         Ok(_) => None,
         Err(e) => Some(e.details),
     };
@@ -57,10 +56,40 @@ async fn main() -> Result<()> {
     disable_raw_mode()?;
 
     match error_msg {
-        Some(x) => {
-            eprintln!("{}", x);
-            std::process::exit(1);
-        }
-        None => return Ok(()),
+        Some(x) => fail(&x),
+        None => Ok(()),
     }
+}
+
+/// Lists pods in every namespace at once; a namespace that cannot be read stays in
+/// the list carrying its error instead of disappearing.
+async fn collect_namespaces(client: &Client, names: Vec<String>) -> Vec<NamespaceEntry> {
+    let fetches = names
+        .iter()
+        .map(|name| MyPod::get_pods_by_ns(client, name))
+        .collect::<Vec<_>>();
+
+    let results = join_all(fetches).await;
+
+    names
+        .into_iter()
+        .zip(results)
+        .map(|(name, result)| match result {
+            Ok(pods) => NamespaceEntry {
+                name,
+                pods,
+                error: None,
+            },
+            Err(e) => NamespaceEntry {
+                name,
+                pods: vec![],
+                error: Some(e.details),
+            },
+        })
+        .collect()
+}
+
+fn fail(message: &str) -> ! {
+    eprintln!("{}", message);
+    std::process::exit(1);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,17 +3,16 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
     ExecutableCommand,
 };
-use futures::future::join_all;
 use giter::config::config::Args;
-use giter::drawer::app::{App, NamespaceEntry};
+use giter::drawer::app::App;
 use giter::drawer::terminal::process_frames;
-use giter::k8s::client;
-use giter::k8s::pods::MyPod;
+use giter::drawer::theme::Theme;
+use giter::k8s::{client, context};
 use giter::storage::common::Storage;
 use giter::storage::json_storage::JsonStorage;
 use kube::Client;
 use ratatui::prelude::*;
-use std::io::{stdout, Result};
+use std::io::{stdout, Error, Result};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -38,55 +37,53 @@ async fn main() -> Result<()> {
         Err(e) => fail(&e.details),
     };
 
-    let namespaces = collect_namespaces(&kube_client, names).await;
-    let mut app = App::new(namespaces, repos, args.mode);
+    let cluster = context::current();
+    let theme = Theme::new(cluster.env, args.colorblind);
 
+    // pods and git references are fetched in the background, so the table is on screen
+    // before the cluster has answered anything
+    let mut app = App::new(names, repos, args.mode, cluster, kube_client);
+
+    guard_against_panics();
+
+    let outcome = run(&mut app, &theme);
+    restore();
+
+    match outcome {
+        Err(e) => fail(&e.to_string()),
+        Ok(_) => Ok(()),
+    }
+}
+
+/// Puts the terminal into its drawing state and runs the loop. Restoring it is left to the
+/// caller, so that a failure part way through here cannot strand the user in raw mode.
+fn run(app: &mut App, theme: &Theme) -> Result<()> {
     stdout().execute(EnterAlternateScreen)?;
     enable_raw_mode()?;
+
     let mut terminal: Terminal<CrosstermBackend<std::io::Stdout>> =
         Terminal::new(CrosstermBackend::new(stdout()))?;
     terminal.clear()?;
 
-    let error_msg = match process_frames(terminal, &mut app) {
-        Ok(_) => None,
-        Err(e) => Some(e.details),
-    };
-
-    stdout().execute(LeaveAlternateScreen)?;
-    disable_raw_mode()?;
-
-    match error_msg {
-        Some(x) => fail(&x),
-        None => Ok(()),
-    }
+    // the draw loop blocks its thread; this hands the runtime's other work to another one
+    tokio::task::block_in_place(|| process_frames(terminal, app, theme))
+        .map_err(|e| Error::other(e.details))
 }
 
-/// Lists pods in every namespace at once; a namespace that cannot be read stays in
-/// the list carrying its error instead of disappearing.
-async fn collect_namespaces(client: &Client, names: Vec<String>) -> Vec<NamespaceEntry> {
-    let fetches = names
-        .iter()
-        .map(|name| MyPod::get_pods_by_ns(client, name))
-        .collect::<Vec<_>>();
+/// A panic unwinds past the restore below, which would leave the caller's terminal in raw
+/// mode with no way back short of `reset`.
+fn guard_against_panics() {
+    let report = std::panic::take_hook();
 
-    let results = join_all(fetches).await;
+    std::panic::set_hook(Box::new(move |info| {
+        restore();
+        report(info);
+    }));
+}
 
-    names
-        .into_iter()
-        .zip(results)
-        .map(|(name, result)| match result {
-            Ok(pods) => NamespaceEntry {
-                name,
-                pods,
-                error: None,
-            },
-            Err(e) => NamespaceEntry {
-                name,
-                pods: vec![],
-                error: Some(e.details),
-            },
-        })
-        .collect()
+fn restore() {
+    let _ = stdout().execute(LeaveAlternateScreen);
+    let _ = disable_raw_mode();
 }
 
 fn fail(message: &str) -> ! {

--- a/src/storage/json_storage.rs
+++ b/src/storage/json_storage.rs
@@ -16,6 +16,11 @@ impl JsonStorage {
     pub fn get_repo_by_name(&self, name: &str) -> Option<&Repo> {
         self.repos.iter().find(|r| r.name == name)
     }
+
+    #[cfg(test)]
+    pub fn from_repos(repos: Vec<Repo>) -> JsonStorage {
+        JsonStorage { repos }
+    }
 }
 
 impl Storage for JsonStorage {

--- a/src/storage/json_storage.rs
+++ b/src/storage/json_storage.rs
@@ -6,22 +6,15 @@ pub struct JsonStorage {
 }
 
 impl JsonStorage {
-    pub fn new(file_path: &'static str) -> Result<JsonStorage, Box<dyn Error>> {
-        let raw_string = match fs::read_to_string(file_path) {
-            Ok(f) => f,
-            Err(e) => return Err(Box::new(e)),
-        };
-
-        let repos: Vec<Repo> = match serde_json::from_str(&raw_string) {
-            Ok(data) => data,
-            Err(e) => return Err(Box::new(e)),
-        };
+    pub fn new(file_path: &str) -> Result<JsonStorage, Box<dyn Error>> {
+        let raw_string = fs::read_to_string(file_path)?;
+        let repos: Vec<Repo> = serde_json::from_str(&raw_string)?;
 
         Ok(JsonStorage { repos })
     }
 
-    pub fn get_repo_by_name(&self, name: &String) -> Option<&Repo> {
-        self.repos.iter().filter(|r| r.name == *name).next()
+    pub fn get_repo_by_name(&self, name: &str) -> Option<&Repo> {
+        self.repos.iter().find(|r| r.name == name)
     }
 }
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,0 +1,318 @@
+//! Text shaping shared by the renderers. Names in this tool are long and share long
+//! prefixes, so the layout dims what repeats instead of cutting off what does not.
+
+/// Parts of a pod name the renderer dims differently: the workload prefix, the
+/// ReplicaSet hash, and the suffix that actually tells one pod from another.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PodName<'a> {
+    pub prefix: &'a str,
+    pub replicaset: &'a str,
+    pub suffix: &'a str,
+}
+
+/// Family a name belongs to: its first `-`-delimited prefix that at least one other name
+/// shares. With `orchard-*` and `nimbus-*` side by side this picks `orchard-` and
+/// `nimbus-`, and nothing for a name that stands alone.
+pub fn family_prefix<'a>(name: &'a str, names: &[String]) -> &'a str {
+    for (index, _) in name.char_indices().filter(|(_, c)| *c == '-') {
+        let prefix = &name[..index + 1];
+
+        // the name itself is in the list, so two matches mean one other name
+        if names
+            .iter()
+            .filter(|other| other.starts_with(prefix))
+            .count()
+            >= 2
+        {
+            return prefix;
+        }
+    }
+
+    ""
+}
+
+/// The part of a name that tells nothing, because every member of its family repeats it.
+/// Dimmed rather than cut, so the telling part is always on screen.
+pub fn shared_prefix<'a>(name: &'a str, names: &[String]) -> &'a str {
+    let family = family_prefix(name, names);
+    if family.is_empty() {
+        return "";
+    }
+
+    let mut longest = family;
+
+    for (index, _) in name.char_indices().filter(|(_, c)| *c == '-') {
+        let candidate = &name[..index + 1];
+
+        if candidate.len() > family.len()
+            && names
+                .iter()
+                .filter(|other| other.starts_with(family))
+                .all(|other| other.starts_with(candidate))
+        {
+            longest = candidate;
+        }
+    }
+
+    longest
+}
+
+/// Splits `orchard-gateway-6b9f4c2d71-q8xzv` into the workload prefix, the
+/// ReplicaSet hash and the unique suffix.
+pub fn split_pod_name<'a>(pod: &'a str, namespace: &str) -> PodName<'a> {
+    let (prefix, rest) = match pod.strip_prefix(namespace) {
+        Some(rest) if rest.starts_with('-') => pod.split_at(namespace.len() + 1),
+        _ => ("", pod),
+    };
+
+    match rest.rfind('-') {
+        Some(cut) => PodName {
+            prefix,
+            replicaset: &rest[..cut + 1],
+            suffix: &rest[cut + 1..],
+        },
+        None => PodName {
+            prefix,
+            replicaset: "",
+            suffix: rest,
+        },
+    }
+}
+
+/// Compact age in the shape `kubectl` uses: `45s`, `12m`, `4h`, `6d`.
+pub fn short_duration(seconds: i64) -> String {
+    match seconds.max(0) {
+        s if s < 60 => format!("{}s", s),
+        s if s < 3_600 => format!("{}m", s / 60),
+        s if s < 86_400 => format!("{}h", s / 3_600),
+        s => format!("{}d", s / 86_400),
+    }
+}
+
+/// Fits `head` and `tail` into `width` characters by eating the head from the left,
+/// because the head is the part every name repeats. The tail is only cut when it does not
+/// fit on its own.
+pub fn fit_head(head: &str, tail: &str, width: usize) -> (String, String) {
+    let tail_len = tail.chars().count();
+    let head_len = head.chars().count();
+
+    if head_len + tail_len <= width {
+        return (head.to_string(), tail.to_string());
+    }
+
+    if tail_len >= width {
+        return (String::new(), ellipsize(tail, width));
+    }
+
+    match width - tail_len {
+        0 => (String::new(), tail.to_string()),
+        1 => ("…".to_string(), tail.to_string()),
+        room => (
+            format!(
+                "…{}",
+                head.chars().skip(head_len - room + 1).collect::<String>()
+            ),
+            tail.to_string(),
+        ),
+    }
+}
+
+/// Cuts `text` down to `width` characters, marking the cut with an ellipsis.
+pub fn ellipsize(text: &str, width: usize) -> String {
+    if text.chars().count() <= width {
+        return text.to_string();
+    }
+
+    match width {
+        0 => String::new(),
+        1 => "…".to_string(),
+        _ => text.chars().take(width - 1).chain(['…']).collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use speculoos::prelude::*;
+
+    fn names(names: &[&str]) -> Vec<String> {
+        names.iter().map(|n| n.to_string()).collect()
+    }
+
+    #[test]
+    fn family_is_the_first_prefix_another_name_shares() {
+        let all = names(&[
+            "orchard-gateway",
+            "orchard-ledger-api",
+            "nimbus-index-component",
+        ]);
+
+        asserting!("a family groups a whole product, not one of its levels")
+            .that(&family_prefix("orchard-ledger-api", &all))
+            .is_equal_to("orchard-");
+    }
+
+    #[test]
+    fn prefix_the_whole_family_repeats_is_dimmed_in_full() {
+        let all = names(&["nimbus-cache-component", "nimbus-cache-warmer"]);
+
+        assert_that!(shared_prefix("nimbus-cache-component", &all)).is_equal_to("nimbus-cache-");
+    }
+
+    #[test]
+    fn prefix_stops_where_the_family_diverges() {
+        let all = names(&[
+            "nimbus-cache-component",
+            "nimbus-cache-warmer",
+            "nimbus-index-component",
+        ]);
+
+        asserting!("dimming nimbus-cache- would hide what tells the two apart")
+            .that(&shared_prefix("nimbus-cache-component", &all))
+            .is_equal_to("nimbus-");
+    }
+
+    #[test]
+    fn name_outside_any_family_is_shown_whole() {
+        let all = names(&["driftwood", "orchard-gateway", "orchard-ledger-api"]);
+
+        assert_that!(shared_prefix("driftwood", &all)).is_equal_to("");
+    }
+
+    #[test]
+    fn name_standing_alone_keeps_its_whole_label() {
+        let all = names(&["pigeon-post", "orchard-gateway", "driftwood"]);
+
+        assert_that!(family_prefix("pigeon-post", &all)).is_equal_to("");
+    }
+
+    #[test]
+    fn name_without_a_separator_has_no_prefix() {
+        let all = names(&["driftwood", "driftwood-proxy"]);
+
+        assert_that!(family_prefix("driftwood", &all)).is_equal_to("");
+    }
+
+    #[test]
+    fn pod_name_gives_up_the_namespace_prefix() {
+        let parts = split_pod_name("orchard-gateway-6b9f4c2d71-q8xzv", "orchard-gateway");
+
+        assert_that!(parts.prefix).is_equal_to("orchard-gateway-");
+    }
+
+    #[test]
+    fn pod_name_keeps_the_replicaset_hash_apart() {
+        let parts = split_pod_name("pigeon-post-58d3a0e4bc-mk2wr", "pigeon-post");
+
+        assert_that!(parts.replicaset).is_equal_to("58d3a0e4bc-");
+    }
+
+    #[test]
+    fn pod_name_ends_with_the_telling_suffix() {
+        let suffix = "vd6np";
+        let name = format!("tulip-mailer-7c1b9e5a04-{}", suffix);
+        let parts = split_pod_name(&name, "tulip-mailer");
+
+        assert_that!(parts.suffix).is_equal_to(suffix);
+    }
+
+    #[test]
+    fn stateful_set_pod_has_no_replicaset_hash() {
+        let parts = split_pod_name("driftwood-0", "driftwood");
+
+        asserting!("an ordinal is not a ReplicaSet hash")
+            .that(&parts.replicaset)
+            .is_equal_to("");
+    }
+
+    #[test]
+    fn pod_not_named_after_its_namespace_keeps_the_whole_name() {
+        let parts = split_pod_name("mesh-ingress-abc12-xyz", "orchard-gateway");
+
+        assert_that!(parts.prefix).is_equal_to("");
+    }
+
+    #[test]
+    fn age_below_a_minute_is_counted_in_seconds() {
+        assert_that!(short_duration(42)).is_equal_to("42s".to_string());
+    }
+
+    #[test]
+    fn age_below_an_hour_is_counted_in_minutes() {
+        assert_that!(short_duration(18 * 60 + 30)).is_equal_to("18m".to_string());
+    }
+
+    #[test]
+    fn age_below_a_day_is_counted_in_hours() {
+        assert_that!(short_duration(5 * 3_600)).is_equal_to("5h".to_string());
+    }
+
+    #[test]
+    fn older_than_a_day_is_counted_in_days() {
+        assert_that!(short_duration(6 * 86_400 + 7_000)).is_equal_to("6d".to_string());
+    }
+
+    #[test]
+    fn clock_skew_does_not_produce_a_negative_age() {
+        asserting!("a pod created in the future is shown as brand new")
+            .that(&short_duration(-90))
+            .is_equal_to("0s".to_string());
+    }
+
+    #[test]
+    fn text_that_fits_is_left_alone() {
+        let tag = "v1.4.7-8112430";
+
+        assert_that!(ellipsize(tag, 20)).is_equal_to(tag.to_string());
+    }
+
+    #[test]
+    fn text_that_does_not_fit_is_marked_as_cut() {
+        assert_that!(ellipsize("CrashLoopBackOff", 9)).is_equal_to("CrashLoo…".to_string());
+    }
+
+    #[test]
+    fn multibyte_text_is_cut_by_characters() {
+        asserting!("cutting by bytes would split the ellipsis of the previous cut")
+            .that(&ellipsize("не влезает", 4))
+            .is_equal_to("не …".to_string());
+    }
+
+    #[test]
+    fn no_room_at_all_yields_nothing() {
+        assert_that!(ellipsize("forbidden", 0)).is_equal_to(String::new());
+    }
+
+    #[test]
+    fn head_and_tail_that_fit_are_left_alone() {
+        let (head, _) = fit_head("orchard-", "gateway", 20);
+
+        assert_that!(head).is_equal_to("orchard-".to_string());
+    }
+
+    #[test]
+    fn head_gives_up_room_before_the_tail_does() {
+        let (head, _) = fit_head("orchard-ledger-", "worker", 16);
+
+        asserting!("the repeated part is the one worth losing")
+            .that(&head)
+            .is_equal_to("…d-ledger-".to_string());
+    }
+
+    #[test]
+    fn telling_tail_survives_a_narrow_column() {
+        let suffix = "vd6np";
+        let (_, tail) = fit_head("tulip-mailer-7c1b9e5a04-", suffix, 9);
+
+        assert_that!(tail).is_equal_to(suffix.to_string());
+    }
+
+    #[test]
+    fn tail_longer_than_the_column_is_cut_itself() {
+        let (head, tail) = fit_head("nimbus-", "cache-component", 8);
+
+        asserting!("nothing else can be given up at this point")
+            .that(&(head, tail))
+            .is_equal_to((String::new(), "cache-c…".to_string()));
+    }
+}


### PR DESCRIPTION
## What this does

`giter` used to answer "which commit is deployed" for one namespace at a time, across three
equal panes, with a single footer line that mixed the mode, the errors and the key hints.
Finding a stale deployment meant walking every namespace by hand.

It now opens on a table of every namespace listed in `repos.json`, worst first, and compares
what each pod runs against what it should:

- `--mode commit` — the tip of the default branch (`git ls-remote <url> HEAD`)
- `--mode tag` — the commit behind the latest version tag, which is what production is
  supposed to run

`Enter` takes a namespace apart: its pods with what they run, their status, restarts, age and
readiness, and the containers of the selected pod. No API token is needed — `git ls-remote`
uses the credentials already configured.

## Worth knowing

- **Every row carries a glyph as well as a colour**, plus a short code where there is nothing
  to compare (`sidecar`, `digest`, `no-cfg`, `no-tags`, `mode`, `done`, `no-pods`), so the
  reasons that used to share one shade of grey are told apart. It reads in a monochrome
  terminal, and `--colorblind` swaps green and red for blue and orange.
- **The header names the cluster** and tints itself by environment, taken from the kubeconfig
  context, because mistaking production for staging was the easiest mistake to make.
- **Nothing blocks the interface.** Pods and references are fetched in the background, and the
  table is on screen before the cluster has answered anything.
- **What cannot be judged is left out of a verdict** rather than dragging it down: a sidecar
  pinned to its own version, somebody else's pod sharing the namespace, and a pod a CronJob
  left behind all say nothing about the release.
- Search, a filter, a sort, a help popup with the full key map and legend, a layout for eighty
  columns and a refusal to draw anything below 60×15.

## Breaking changes

- `-n/--namespace` no longer defaults to the current kubeconfig namespace: without it every
  namespace from `repos.json` is shown, with it the view is limited to one.
- The keys changed: `Enter` opens a namespace on the overview and a commit on the namespace
  screen, `Esc` steps back instead of quitting outright.
- The library's status model was rebuilt — `CommitStatus` gave way to `Verdict`, `RemoteState`
  gained variants, and `App::new` takes the cluster and a Kubernetes client.
- `git` is now required in `PATH`.
